### PR TITLE
Complete Initiation Flow

### DIFF
--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -89,6 +89,7 @@ mkQVFPolicy oref deadline tn _ ctx =
       -- }}}
 
     validateTwoOutputs o0 o1 =
+      -- {{{
          traceIfFalse
            "Missing governance token in the deadline UTxO."
            (utxoHasX ownSym (Just tn) o0)
@@ -117,6 +118,7 @@ mkQVFPolicy oref deadline tn _ ctx =
                  "Either invalid datums produced, or produced in wrong order."
                -- }}}
          )
+      -- }}}
 
     validOutputsPresent :: Bool
     validOutputsPresent =
@@ -223,144 +225,3 @@ qvfSymbol :: TxOutRef -> POSIXTime -> CurrencySymbol
 qvfSymbol oref deadline = scriptCurrencySymbol $ qvfPolicy oref deadline
 
 
-x :: Data
-x =
-  Constr 0 -- ScriptContext
-    [ Constr 0 -- scriptContextTxInfo
-        -- {{{
-        [ List     -- txInfoInputs
-            -- {{{
-            [ Constr 0 -- TxInInfo
-                [ Constr 0 -- txInInfoOutRef
-                    [ Constr 0
-                        [ B "\140O\142\210\150\DC4\148\191a\170\163\227\174\r\245\SUB4~\217\220\186>L\236i\183\160:\230o\154\213"
-                        ]
-                    , I 0
-                    ]
-                , Constr 0 -- txInInfoResolved
-                    [ Constr 0 -- txOutAddress
-                        [ Constr 0
-                            [ B "n\188\b\178\DC1\190{ <\188T\238\252\202\150\EM\ETB5V\ETX&\211\145\154\188\162B["
-                            ]
-                        , Constr 1 []
-                        ]
-                    , Map [(B "", Map [(B "", I 9757062140)])] -- txOutValue
-                    , Constr 0 [] -- txOutDatum
-                    , Constr 1 [] -- txOutReferenceScript
-                    ]
-                ]
-            ]
-            -- }}}
-        , List     -- txInfoReferenceInputs
-            -- {{{
-            []
-            -- }}}
-        , List     -- txInfoOutputs
-            -- {{{
-            [ Constr 0 -- TxOut
-                -- {{{
-                [ Constr 0 -- txOutAddress
-                    [ Constr 0
-                        [ B "n\188\b\178\DC1\190{ <\188T\238\252\202\150\EM\ETB5V\ETX&\211\145\154\188\162B["
-                        ]
-                    , Constr 1 []
-                    ]
-                , Map [(B "", Map [(B "", I 9753617579)])] -- txOutValue
-                , Constr 0 [] -- txOutDatum
-                , Constr 1 [] -- txOutReferenceScript
-                ]
-                -- }}}
-            , Constr 0 -- TxOut
-                -- {{{
-                [ Constr 0 -- txOutAddress
-                    [ Constr 1
-                        [ B "E\132,\173\238\170\174\220t\237\249\250\185\194\138\198\v+\229\152<\169[a\241\138\SIp"
-                        ]
-                    , Constr 1 []
-                    ]
-                , Map -- txOutValue
-                    [ (B "", Map [(B "", I 1500000)])
-                    , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
-                      , Map [(B "QVF", I 1)]
-                      )
-                    ]
-                , Constr 2 [Constr 0 [I 1667642400000]] -- txOutDatum
-                , Constr 1 [] -- txOutReferenceScript
-                ]
-                -- }}}
-            , Constr 0 -- TxOut
-                -- {{{
-                [ Constr 0 -- txOutAddress
-                    [ Constr 1
-                        [ B "E\132,\173\238\170\174\220t\237\249\250\185\194\138\198\v+\229\152<\169[a\241\138\SIp"
-                        ]
-                    , Constr 1 []
-                    ]
-                , Map -- txOutValue
-                    [ (B "", Map [(B "", I 1500000)])
-                    , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
-                      , Map [(B "QVF" , I 1)]
-                      )
-                    ]
-                , Constr 2 [Constr 1 [I 0]] -- txOutDatum
-                , Constr 1 [] -- txOutReferenceScript
-                ]
-                -- }}}
-            ]
-            -- }}}
-        , Map      -- txInfoFee
-            -- {{{
-            [(B "", Map [(B "", I 444561)])]
-            -- }}}
-        , Map      -- txInfoMint
-            -- {{{
-            [ (B "", Map [(B "" , I 0)])
-            , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
-              , Map [(B "QVF", I 2)]
-              )
-            ]
-            -- }}}
-        , List     -- txInfoDCert
-            -- {{{
-            []
-            -- }}}
-        , Map      -- txInfoWdrl
-            -- {{{
-            []
-            -- }}}
-        , Constr 0 -- txInfoValidRange
-            -- {{{
-            [ Constr 0 [Constr 0 [], Constr 1 []]
-            , Constr 0 [Constr 1 [I 1665115486000] ,Constr 1 []]
-            ]
-            -- }}}
-        , List     -- txInfoSignatories
-            -- {{{
-            []
-            -- }}}
-        , Map      -- txInfoRedeemers
-            -- {{{
-            [ ( Constr 0 -- Minting :: ScriptPurpose
-                  [ B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
-                  ]
-              , I 0      -- Redeemer
-              )
-            ]
-            -- }}}
-        , Map      -- txInfoData
-            -- {{{
-            []
-            -- }}}
-        , Constr 0 -- txInfoId
-            -- {{{
-            [ B "Fg%\147\195c\172\155z~\229\251\248\STX\t\214\ETX\184\166\232q\236\165m\242\DLEpk\143\251i\207"
-            ]
-            -- }}}
-        ]
-        -- }}}
-    , Constr 0 -- Minting :: ScriptPurpose
-        -- {{{
-        [ B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
-        ]
-        -- }}}
-    ]

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -47,10 +47,10 @@ qvfTokenName = TokenName "QVF"
 mkQVFPolicy :: TxOutRef
             -> POSIXTime
             -> TokenName
-            -> ()
+            -> BuiltinData
             -> ScriptContext
             -> Bool
-mkQVFPolicy oref deadline tn () ctx =
+mkQVFPolicy oref deadline tn _ ctx =
   -- {{{
   let
     info :: TxInfo
@@ -88,40 +88,111 @@ mkQVFPolicy oref deadline tn () ctx =
           -- }}}
       -- }}}
 
+    validateTwoOutputs o0 o1 =
+         traceIfFalse
+           "Missing governance token in the deadline UTxO."
+           (utxoHasX ownSym (Just tn) o0)
+      && traceIfFalse
+           "Missing governance token in the main UTxO."
+           (utxoHasX ownSym (Just tn) o1)
+      && ( case (getInlineDatum o0, getInlineDatum o1) of
+             (DeadlineDatum dl, RegisteredProjectsCount count) ->
+               -- {{{
+                  traceIfFalse
+                    "Deadline must match with the provided parameter."
+                    (dl == deadline)
+               && traceIfFalse
+                    "Funding round must start with 0 registered projects."
+                    (count == 0)
+               && traceIfFalse
+                    "Deadline UTxO must carry the required Lovelaces."
+                    (utxoHasLovelaces governanceLovelaces o0)
+               && traceIfFalse
+                    "Governance UTxO must carry the required Lovelaces."
+                    (utxoHasLovelaces governanceLovelaces o1)
+               -- }}}
+             _                                                 ->
+               -- {{{
+               traceError
+                 "Either invalid datums produced, or produced in wrong order."
+               -- }}}
+         )
+
     validOutputsPresent :: Bool
     validOutputsPresent =
       -- {{{
-      case filter (utxoHasX ownSym (Just tn)) (txInfoOutputs info) of
-        -- TODO: Is expecting a specific order possible?
-        [o0, o1] ->
+      case txInfoOutputs info of
+        [o0, o1]    ->
           -- {{{
-          case (getInlineDatum o0, getInlineDatum o1) of
-            (DeadlineDatum dl, RegisteredProjectsCount count) ->
-              -- {{{
-                 traceIfFalse
-                   "Deadline must match with the provided parameter."
-                   (dl == deadline)
-              && traceIfFalse
-                   "Funding round must start with 0 registered projects."
-                   (count == 0)
-              && traceIfFalse
-                   "Governance UTxO must carry the required Lovelaces."
-                   (utxoHasLovelaces governanceLovelaces o0)
-              && traceIfFalse
-                   "Governance UTxO must carry the required Lovelaces."
-                   (utxoHasLovelaces governanceLovelaces o1)
-              -- }}}
-            _                                                 ->
-              -- {{{
-              traceError
-                "Either invalid datums produced, or produced in wrong order."
-              -- }}}
+          validateTwoOutputs o0 o1
           -- }}}
-        _        ->
+        [_, o0, o1] ->
+          -- {{{
+          validateTwoOutputs o0 o1
+          -- }}}
+        _           ->
           -- {{{
           traceError "The 2 minted tokens must be split among 2 UTxOs."
           -- }}}
       -- }}}
+
+    -- validDeadlineOutput :: Bool
+    -- validMainOutput     :: Bool
+    -- (validDeadlineOutput, validMainOutput) =
+    --   -- {{{
+    --   let
+    --     go []            acc                     = acc
+    --     go (utxo : rest) acc@(dlFound, rpcFound) =
+    --       if utxoHasX ownSym (Just tn) utxo then
+    --         -- {{{
+    --         if dlFound then
+    --           -- {{{
+    --           case getInlineDatum utxo of
+    --             RegisteredProjectsCount count ->
+    --               -- {{{
+    --               ( dlFound
+    --               ,    traceIfFalse
+    --                      "Funding round must start with 0 registered projects."
+    --                      (count == 0)
+    --                 && traceIfFalse
+    --                      "Governance UTxO must carry the required Lovelaces."
+    --                      (utxoHasLovelaces governanceLovelaces utxo)
+    --               )
+    --               -- }}}
+    --             _                             ->
+    --               -- {{{
+    --               traceError "Invalid datum for the second UTxO."
+    --               -- }}}
+    --           -- }}}
+    --         else
+    --           -- {{{
+    --           case getInlineDatum utxo of
+    --             DeadlineDatum dl ->
+    --               -- {{{
+    --               let
+    --                 cond =
+    --                      traceIfFalse
+    --                        "Deadline must match with the provided parameter."
+    --                        (dl == deadline)
+    --                   && traceIfFalse
+    --                        "Deadline UTxO must carry the required Lovelaces."
+    --                        (utxoHasLovelaces governanceLovelaces utxo)
+    --               in
+    --               go rest (cond, rpcFound)
+    --               -- }}}
+    --             _                ->
+    --               -- {{{
+    --               traceError "Deadline UTxO must be produced first."
+    --               -- }}}
+    --           -- }}}
+    --         -- }}}
+    --       else
+    --         -- {{{
+    --         go rest acc
+    --         -- }}}
+    --   in
+    --   go (txInfoOutputs info) (False, False)
+    --   -- }}}
   in
      traceIfFalse "UTxO not consumed." hasUTxO
   && traceIfFalse "Deadline has passed." deadlineIsValid
@@ -133,8 +204,12 @@ mkQVFPolicy oref deadline tn () ctx =
 qvfPolicy :: TxOutRef -> POSIXTime -> MintingPolicy
 qvfPolicy oref deadline =
   -- {{{
+  let
+    wrap :: (BuiltinData -> ScriptContext -> Bool) -> PSU.V2.UntypedMintingPolicy
+    wrap = PSU.V2.mkUntypedMintingPolicy
+  in
   Plutonomy.optimizeUPLC $ mkMintingPolicyScript $
-    $$(PlutusTx.compile [|| \oref' deadline' tn' -> PSU.V2.mkUntypedMintingPolicy $ mkQVFPolicy oref' deadline' tn' ||])
+    $$(PlutusTx.compile [|| \oref' deadline' tn' -> wrap $ mkQVFPolicy oref' deadline' tn' ||])
     `PlutusTx.applyCode`
     PlutusTx.liftCode oref
     `PlutusTx.applyCode`
@@ -146,3 +221,146 @@ qvfPolicy oref deadline =
 
 qvfSymbol :: TxOutRef -> POSIXTime -> CurrencySymbol
 qvfSymbol oref deadline = scriptCurrencySymbol $ qvfPolicy oref deadline
+
+
+x :: Data
+x =
+  Constr 0 -- ScriptContext
+    [ Constr 0 -- scriptContextTxInfo
+        -- {{{
+        [ List     -- txInfoInputs
+            -- {{{
+            [ Constr 0 -- TxInInfo
+                [ Constr 0 -- txInInfoOutRef
+                    [ Constr 0
+                        [ B "\140O\142\210\150\DC4\148\191a\170\163\227\174\r\245\SUB4~\217\220\186>L\236i\183\160:\230o\154\213"
+                        ]
+                    , I 0
+                    ]
+                , Constr 0 -- txInInfoResolved
+                    [ Constr 0 -- txOutAddress
+                        [ Constr 0
+                            [ B "n\188\b\178\DC1\190{ <\188T\238\252\202\150\EM\ETB5V\ETX&\211\145\154\188\162B["
+                            ]
+                        , Constr 1 []
+                        ]
+                    , Map [(B "", Map [(B "", I 9757062140)])] -- txOutValue
+                    , Constr 0 [] -- txOutDatum
+                    , Constr 1 [] -- txOutReferenceScript
+                    ]
+                ]
+            ]
+            -- }}}
+        , List     -- txInfoReferenceInputs
+            -- {{{
+            []
+            -- }}}
+        , List     -- txInfoOutputs
+            -- {{{
+            [ Constr 0 -- TxOut
+                -- {{{
+                [ Constr 0 -- txOutAddress
+                    [ Constr 0
+                        [ B "n\188\b\178\DC1\190{ <\188T\238\252\202\150\EM\ETB5V\ETX&\211\145\154\188\162B["
+                        ]
+                    , Constr 1 []
+                    ]
+                , Map [(B "", Map [(B "", I 9753617579)])] -- txOutValue
+                , Constr 0 [] -- txOutDatum
+                , Constr 1 [] -- txOutReferenceScript
+                ]
+                -- }}}
+            , Constr 0 -- TxOut
+                -- {{{
+                [ Constr 0 -- txOutAddress
+                    [ Constr 1
+                        [ B "E\132,\173\238\170\174\220t\237\249\250\185\194\138\198\v+\229\152<\169[a\241\138\SIp"
+                        ]
+                    , Constr 1 []
+                    ]
+                , Map -- txOutValue
+                    [ (B "", Map [(B "", I 1500000)])
+                    , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
+                      , Map [(B "QVF", I 1)]
+                      )
+                    ]
+                , Constr 2 [Constr 0 [I 1667642400000]] -- txOutDatum
+                , Constr 1 [] -- txOutReferenceScript
+                ]
+                -- }}}
+            , Constr 0 -- TxOut
+                -- {{{
+                [ Constr 0 -- txOutAddress
+                    [ Constr 1
+                        [ B "E\132,\173\238\170\174\220t\237\249\250\185\194\138\198\v+\229\152<\169[a\241\138\SIp"
+                        ]
+                    , Constr 1 []
+                    ]
+                , Map -- txOutValue
+                    [ (B "", Map [(B "", I 1500000)])
+                    , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
+                      , Map [(B "QVF" , I 1)]
+                      )
+                    ]
+                , Constr 2 [Constr 1 [I 0]] -- txOutDatum
+                , Constr 1 [] -- txOutReferenceScript
+                ]
+                -- }}}
+            ]
+            -- }}}
+        , Map      -- txInfoFee
+            -- {{{
+            [(B "", Map [(B "", I 444561)])]
+            -- }}}
+        , Map      -- txInfoMint
+            -- {{{
+            [ (B "", Map [(B "" , I 0)])
+            , ( B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
+              , Map [(B "QVF", I 2)]
+              )
+            ]
+            -- }}}
+        , List     -- txInfoDCert
+            -- {{{
+            []
+            -- }}}
+        , Map      -- txInfoWdrl
+            -- {{{
+            []
+            -- }}}
+        , Constr 0 -- txInfoValidRange
+            -- {{{
+            [ Constr 0 [Constr 0 [], Constr 1 []]
+            , Constr 0 [Constr 1 [I 1665115486000] ,Constr 1 []]
+            ]
+            -- }}}
+        , List     -- txInfoSignatories
+            -- {{{
+            []
+            -- }}}
+        , Map      -- txInfoRedeemers
+            -- {{{
+            [ ( Constr 0 -- Minting :: ScriptPurpose
+                  [ B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
+                  ]
+              , I 0      -- Redeemer
+              )
+            ]
+            -- }}}
+        , Map      -- txInfoData
+            -- {{{
+            []
+            -- }}}
+        , Constr 0 -- txInfoId
+            -- {{{
+            [ B "Fg%\147\195c\172\155z~\229\251\248\STX\t\214\ETX\184\166\232q\236\165m\242\DLEpk\143\251i\207"
+            ]
+            -- }}}
+        ]
+        -- }}}
+    , Constr 0 -- Minting :: ScriptPurpose
+        -- {{{
+        [ B "\178\RS\144\156\215\SOH\165W%\\}4\138E\233M\NUL#sM\234+p\DC3\246\202\&4\174"
+        ]
+        -- }}}
+    ]

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -28,6 +28,7 @@ import           Ledger                               ( scriptCurrencySymbol )
 import           Ledger.Value as Value                ( flattenValue )
 import qualified Plutonomy
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
+import qualified Plutus.V1.Ledger.Interval            as Interval
 import           Plutus.V2.Ledger.Api
 import           Plutus.V2.Ledger.Contexts            ( ownCurrencySymbol )
 import qualified PlutusTx

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -106,6 +106,9 @@ mkQVFPolicy oref deadline tn () ctx =
                    (count == 0)
               && traceIfFalse
                    "Governance UTxO must carry the required Lovelaces."
+                   (utxoHasLovelaces governanceLovelaces o0)
+              && traceIfFalse
+                   "Governance UTxO must carry the required Lovelaces."
                    (utxoHasLovelaces governanceLovelaces o1)
               -- }}}
             _                                                 ->

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -59,7 +59,16 @@ mkQVFPolicy oref deadline tn () ctx =
     ownSym = ownCurrencySymbol ctx
 
     hasUTxO :: Bool
-    hasUTxO = utxoIsGettingSpent (txInfoInputs info) oref
+    hasUTxO =
+      -- {{{
+      utxoIsGettingSpent (txInfoInputs info) oref
+      -- }}}
+
+    deadlineIsValid :: Bool
+    deadlineIsValid =
+      -- {{{
+      Interval.to deadline `Interval.contains` txInfoValidRange info
+      -- }}}
 
     checkMintedAmount :: Bool
     checkMintedAmount =
@@ -111,6 +120,7 @@ mkQVFPolicy oref deadline tn () ctx =
       -- }}}
   in
      traceIfFalse "UTxO not consumed." hasUTxO
+  && traceIfFalse "Deadline has passed." deadlineIsValid
   && checkMintedAmount
   && validOutputsPresent
   -- }}}

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -40,6 +40,7 @@ import           Plutus.V1.Ledger.Value               ( flattenValue
                                                       , AssetClass(..) )
 import Plutus.V2.Ledger.Api
 import Plutus.V2.Ledger.Contexts
+import           PlutusTx                             ( Data(..) )
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap                    as Map
 import           PlutusTx.AssocMap                    ( Map )

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -40,7 +40,6 @@ import           Plutus.V1.Ledger.Value               ( flattenValue
                                                       , AssetClass(..) )
 import Plutus.V2.Ledger.Api
 import Plutus.V2.Ledger.Contexts
-import           PlutusTx                             ( Data(..) )
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap                    as Map
 import           PlutusTx.AssocMap                    ( Map )

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -293,7 +293,7 @@ utxoHasX sym mTN =
 utxoHasLovelaces :: Integer -> TxOut -> Bool
 utxoHasLovelaces lovelaces txOut =
   -- {{{
-  txOutValue txOut == Ada.lovelaceValueOf lovelaces
+  Ada.fromValue (txOutValue txOut) == Ada.lovelaceOf lovelaces
   -- }}}
 
 

--- a/qvf-cli/app/CLI.hs
+++ b/qvf-cli/app/CLI.hs
@@ -18,9 +18,7 @@ import           Data.Aeson                 ( encode )
 import qualified Data.ByteString.Char8      as BS8
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.ByteString.Short      as SBS
-import           Data.Either                ( lefts )
 import qualified Data.List                  as List
-import qualified Data.Map                   as Map
 import           Data.Maybe                 ( fromJust )
 import           Data.String                ( fromString )
 import           Data.Time.Clock.POSIX      ( getPOSIXTime )
@@ -260,7 +258,6 @@ main =
           ++ "\t\t, ocfnDonationMinter     :: String\n"
           ++ "\t\t, ocfnQVFMainValidator   :: String\n"
           ++ "\t\t, ocfnDeadlineSlot       :: String\n"
-          ++ "\t\t, ocfnUnitRedeemer       :: String\n"
           ++ "\t\t, ocfnDeadlineDatum      :: String\n"
           ++ "\t\t, ocfnInitialGovDatum    :: String\n"
           ++ "\t\t}"
@@ -474,7 +471,6 @@ main =
               regOF      = ocfnRegistrationMinter
               donOF      = ocfnDonationMinter
               qvfOF      = ocfnQVFMainValidator
-              redeemerOF = ocfnUnitRedeemer
               dlDatOF    = ocfnDeadlineDatum
               initDatOF  = ocfnInitialGovDatum
               dlSlotOF   = ocfnDeadlineSlot
@@ -484,6 +480,7 @@ main =
 
           writeTokenNameHex ocfnTokenNameHex Gov.qvfTokenName
 
+          dlSlot <- getDeadlineSlot currSlot dl
           govRes <- writeMintingPolicy govOF $ Gov.qvfPolicy txRef dl
           regRes <- writeMintingPolicy regOF $ Reg.registrationPolicy qvfSymbol
           donRes <- writeMintingPolicy donOF $ Don.donationPolicy regSymbol
@@ -517,11 +514,9 @@ main =
                     qvfOF
                     (unsafeParseJSON @OutputPlutus)
                     (return ())
-                  dlSlot <- getDeadlineSlot currSlot dl
                   andPrintSuccess
                     dlSlotOF
                     (LBS.writeFile dlSlotOF $ encode dlSlot)
-                  andPrintSuccess redeemerOF $ writeJSON redeemerOF ()
                   andPrintSuccess dlDatOF $ writeJSON dlDatOF $ deadlineDatum dl
                   andPrintSuccess initDatOF $ writeJSON initDatOF initialGovDatum
                   -- }}}
@@ -600,7 +595,6 @@ data OffChainFileNames = OffChainFileNames
   , ocfnDonationMinter     :: String
   , ocfnQVFMainValidator   :: String
   , ocfnDeadlineSlot       :: String
-  , ocfnUnitRedeemer       :: String
   , ocfnDeadlineDatum      :: String
   , ocfnInitialGovDatum    :: String
   } deriving (Generic, A.ToJSON, A.FromJSON)

--- a/qvf-cli/app/CLI.hs
+++ b/qvf-cli/app/CLI.hs
@@ -18,7 +18,9 @@ import           Data.Aeson                 ( encode )
 import qualified Data.ByteString.Char8      as BS8
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.ByteString.Short      as SBS
+import           Data.Either                ( lefts )
 import qualified Data.List                  as List
+import qualified Data.Map                   as Map
 import           Data.Maybe                 ( fromJust )
 import           Data.String                ( fromString )
 import           Data.Time.Clock.POSIX      ( getPOSIXTime )
@@ -42,6 +44,11 @@ import qualified Minter.Registration        as Reg
 
 -- UTILS
 -- {{{
+explainFailure :: String -> Maybe a -> Either String a
+explainFailure errMsg Nothing  = Left errMsg
+explainFailure _      (Just x) = Right x
+
+
 dataToScriptData :: Data -> ScriptData
 -- {{{
 dataToScriptData (Constr n xs) = ScriptDataConstructor n $ dataToScriptData <$> xs
@@ -94,20 +101,17 @@ parseJSONValue bs =
   -- }}}
 
 
-unsafeParsePlutusJSON :: FilePath -> IO OutputPlutus
-unsafeParsePlutusJSON file = do
+unsafeParseJSON :: A.FromJSON a => FilePath -> IO a
+unsafeParseJSON file = do
+  -- {{{
   fileContent <- LBS.readFile file
   let Just decoded = A.decode fileContent
   return decoded
+  -- }}}
 
 
--- TODO !@! - remove? Not used.
--- parseJSON :: FilePath -> IO (Either String Data)
--- parseJSON file = do
---   -- {{{
---   fileContent <- LBS.readFile file
---   parseJSONValue fileContent
---   -- }}}
+-- unsafeParsePlutusJSON :: FilePath -> IO OutputPlutus
+-- unsafeParsePlutusJSON = unsafeParseJSON
 
 
 writeScript :: Serialise a => FilePath -> a -> IO (Either (FileError ()) ())
@@ -249,20 +253,26 @@ main =
     scriptHelp         =
       -- {{{
       makeHelpText
-        (    "Generate the compiled Plutus validation and minting scripts\n"
-          ++ "\t(note the UTxO format):"
+        (    "Generate the compiled Plutus validation and minting scripts.\n\n"
+
+          ++ "\tThe JSON for file names should have these fields:\n\n"
+          ++ "\t\t{ ocfnTokenNameHex       :: String\n"
+          ++ "\t\t, ocfnGovernanceMinter   :: String\n"
+          ++ "\t\t, ocfnRegistrationMinter :: String\n"
+          ++ "\t\t, ocfnDonationMinter     :: String\n"
+          ++ "\t\t, ocfnQVFMainValidator   :: String\n"
+          ++ "\t\t, ocfnDeadlineSlot       :: String\n"
+          ++ "\t\t, ocfnUnitRedeemer       :: String\n"
+          ++ "\t\t, ocfnInitialDatum       :: String\n"
+          ++ "\t\t}"
         )
         "generate"
         "scripts"
         [ "<key-holder-pub-key-hash>"
         , "<txID>#<output-index>"
+        , "<current-slot-number>"
         , "<deadline-posix-milliseconds>"
-        , "<governance-policy.plutus>"
-        , "<registration-policy.plutus>"
-        , "<donation-policy.plutus>"
-        , "<qvf-validator.plutus>"
-        , "<unit.redeemer>"
-        , "<output-initial.datum>"
+        , "{file-names-json}"
         ]
       -- }}}
     deadlineToSlotHelp :: String
@@ -416,6 +426,23 @@ main =
           Left "Bad args."
       -- }}}
 
+    writeTokenNameHex :: FilePath -> TokenName -> IO ()
+    writeTokenNameHex outFile tn =
+      -- {{{
+        LBS.writeFile outFile
+      $ fromString
+      $ unsafeTokenNameToHex tn
+      -- }}}
+
+    getDeadlineSlot :: Integer -> Ledger.POSIXTime -> IO Integer
+    getDeadlineSlot currSlot (Ledger.POSIXTime deadline) = do
+      -- {{{
+      let slotLength = 1000
+      currPOSIX <- round . (* 1000) <$> getPOSIXTime -- milliseconds
+      let diff = deadline - currPOSIX
+      return $ diff `div` slotLength + currSlot
+      -- }}}
+
     mapKeyForKeyHolder :: String
     mapKeyForKeyHolder = "keyHolder"
     -- }}}
@@ -432,15 +459,33 @@ main =
     "-h"       : _                     -> printHelp
     "--help"   : _                     -> printHelp
     "man"      : _                     -> printHelp
-    "generate" : "scripts" : pkhStr : txRefStr : deadlineStr : govOF : regOF : donOF : qvfOF : rOF : dOF : _ -> do
+    "generate" : "scripts" : pkhStr : txRefStr : currSlotStr : deadlineStr : fileNamesJSON : _ ->
       -- {{{
-      case (readTxOutRef txRefStr, Ledger.POSIXTime <$> readMaybe deadlineStr) of
-        (Just txRef, Just dl) -> do
+      let
+        results = ScriptGenerationArgumentsParseResults
+          { sgUTxO      = readTxOutRef txRefStr
+          , sgSlot      = readMaybe currSlotStr
+          , sgDeadline  = Ledger.POSIXTime <$> readMaybe deadlineStr
+          , sgFileNames = A.decode $ fromString fileNamesJSON
+          }
+      in
+      handleScriptGenerationArguments results $
+        \txRef currSlot dl OffChainFileNames{..} -> do
           -- {{{
+          let govOF      = ocfnGovernanceMinter
+              regOF      = ocfnRegistrationMinter
+              donOF      = ocfnDonationMinter
+              qvfOF      = ocfnQVFMainValidator
+              redeemerOF = ocfnUnitRedeemer
+              initDatOF  = ocfnInitialDatum
+              dlSlotOF   = ocfnDeadlineSlot
+              qvfSymbol  = Gov.qvfSymbol txRef dl
+              regSymbol  = Reg.registrationSymbol qvfSymbol
+              donSymbol  = Don.donationSymbol regSymbol
+
+          writeTokenNameHex ocfnTokenNameHex Gov.qvfTokenName
+
           govRes <- writeMintingPolicy govOF $ Gov.qvfPolicy txRef dl
-          let qvfSymbol = Gov.qvfSymbol txRef dl
-              regSymbol = Reg.registrationSymbol qvfSymbol
-              donSymbol = Don.donationSymbol regSymbol
           regRes <- writeMintingPolicy regOF $ Reg.registrationPolicy qvfSymbol
           donRes <- writeMintingPolicy donOF $ Don.donationPolicy regSymbol
           case (govRes, regRes, donRes) of
@@ -457,12 +502,28 @@ main =
               case valRes of
                 Right _ -> do
                   -- {{{
-                  andPrintSuccessWithSize govOF unsafeParsePlutusJSON $ return ()
-                  andPrintSuccessWithSize regOF unsafeParsePlutusJSON $ return ()
-                  andPrintSuccessWithSize donOF unsafeParsePlutusJSON $ return ()
-                  andPrintSuccessWithSize qvfOF unsafeParsePlutusJSON $ return ()
-                  andPrintSuccess rOF $ writeJSON rOF ()
-                  andPrintSuccess dOF $ writeJSON dOF initialDatum
+                  andPrintSuccessWithSize
+                    govOF
+                    (unsafeParseJSON @OutputPlutus)
+                    (return ())
+                  andPrintSuccessWithSize
+                    regOF
+                    (unsafeParseJSON @OutputPlutus)
+                    (return ())
+                  andPrintSuccessWithSize
+                    donOF
+                    (unsafeParseJSON @OutputPlutus)
+                    (return ())
+                  andPrintSuccessWithSize
+                    qvfOF
+                    (unsafeParseJSON @OutputPlutus)
+                    (return ())
+                  dlSlot <- getDeadlineSlot currSlot dl
+                  andPrintSuccess
+                    dlSlotOF
+                    (LBS.writeFile dlSlotOF $ encode dlSlot)
+                  andPrintSuccess redeemerOF $ writeJSON redeemerOF ()
+                  andPrintSuccess initDatOF $ writeJSON initDatOF initialDatum
                   -- }}}
                 Left _  ->
                   -- {{{
@@ -473,14 +534,6 @@ main =
               -- {{{
               putStrLn "FAILED to write minting script files."
               -- }}}
-          -- }}}
-        (Nothing   , _      ) ->
-          -- {{{
-          putStrLn "FAILED to parse the given UTxO."
-          -- }}}
-        (_         , Nothing) ->
-          -- {{{
-          putStrLn "FAILED to parse the deadline."
           -- }}}
       -- }}}
     "pretty-datum" : datumJSONStr : _                                   ->
@@ -502,11 +555,7 @@ main =
         -- }}}
     "string-to-hex" : tn : outFile : _                                  ->
       -- {{{
-      andPrintSuccess outFile
-        $ LBS.writeFile outFile
-        $ fromString
-        $ unsafeTokenNameToHex
-        $ fromString tn
+      andPrintSuccess outFile $ writeTokenNameHex outFile $ fromString tn
       -- }}}
     "get-deadline-slot" : currSlotStr : datumJSON : _                   -> do
       -- {{{
@@ -514,12 +563,10 @@ main =
         Just currSlot -> do
           -- {{{
           actOnData datumJSON $ \case
-            DeadlineDatum (Ledger.POSIXTime deadline) -> do
+            DeadlineDatum dlPOSIX -> do
               -- {{{
-              let slotLength = 1000
-              currPOSIX <- round . (* 1000) <$> getPOSIXTime -- milliseconds
-              let diff       = deadline - currPOSIX
-              print $ diff `div` slotLength + currSlot
+              dlSlot <- getDeadlineSlot currSlot dlPOSIX
+              print dlSlot
               -- }}}
             _                                         ->
               -- {{{
@@ -544,4 +591,90 @@ data OutputPlutus = OutputPlutus
 instance Show OutputPlutus where
   show OutputPlutus{..} =
     show $ lengthOfByteString cborHex
+
+
+data OffChainFileNames = OffChainFileNames
+  { ocfnTokenNameHex       :: String
+  , ocfnGovernanceMinter   :: String
+  , ocfnRegistrationMinter :: String
+  , ocfnDonationMinter     :: String
+  , ocfnQVFMainValidator   :: String
+  , ocfnDeadlineSlot       :: String
+  , ocfnUnitRedeemer       :: String
+  , ocfnInitialDatum       :: String
+  } deriving (Generic, A.ToJSON, A.FromJSON)
+
+
+data ScriptGenerationArgumentsParseResults =
+  ScriptGenerationArgumentsParseResults
+    { sgUTxO      :: Maybe Ledger.TxOutRef
+    , sgSlot      :: Maybe Integer
+    , sgDeadline  :: Maybe Ledger.POSIXTime
+    , sgFileNames :: Maybe OffChainFileNames
+    }
+
+
+unwrapScriptGenerationArgs :: ScriptGenerationArgumentsParseResults
+                           -> Either String ( Ledger.TxOutRef
+                                            , Integer
+                                            , Ledger.POSIXTime
+                                            , OffChainFileNames
+                                            )
+unwrapScriptGenerationArgs ScriptGenerationArgumentsParseResults{..} =
+  -- {{{
+  case (sgUTxO, sgSlot, sgDeadline, sgFileNames) of
+    (Just utxo, Just slot, Just dl, Just fns) ->
+      -- {{{
+      Right (utxo, slot, dl, fns)
+      -- }}}
+    _                                         ->
+      -- {{{
+      let
+        listPrefix     = "\n\t- "
+        utxoError      =
+          -- {{{
+          case sgUTxO of
+            Just _  -> ""
+            Nothing -> listPrefix ++ "Invalid UTxO"
+          -- }}}
+        slotError      =
+          -- {{{
+          case sgSlot of
+            Just _  -> ""
+            Nothing -> listPrefix ++ "Invalid current slot"
+          -- }}}
+        deadlineError  =
+          -- {{{
+          case sgDeadline of
+            Just _  -> ""
+            Nothing -> listPrefix ++ "Invalid deadline POSIX"
+          -- }}}
+        fileNamesError =
+          -- {{{
+          case sgFileNames of
+            Just _  -> ""
+            Nothing -> listPrefix ++ "Invalid JSON for file names"
+          -- }}}
+      in
+      Left $
+           "FAILED: One or more bad arguments found:"
+        ++ utxoError
+        ++ slotError
+        ++ deadlineError
+        ++ fileNamesError
+      -- }}}
+  -- }}}
+
+
+handleScriptGenerationArguments :: ScriptGenerationArgumentsParseResults
+                                -> (Ledger.TxOutRef -> Integer -> Ledger.POSIXTime -> OffChainFileNames -> IO ())
+                                -> IO ()
+handleScriptGenerationArguments results handler =
+  -- {{{
+  case unwrapScriptGenerationArgs results of
+    Right (txRef, currSlot, dl, ocfn) ->
+      handler txRef currSlot dl ocfn
+    Left errMsg                       ->
+      putStrLn errMsg
+  -- }}}
 -- }}}

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -3,25 +3,44 @@ export MAGIC='--testnet-magic 1097911063'
 
 # === CHANGE THESE VARIABLES ACCORDINGLY === #
 export CARDANO_NODE_SOCKET_PATH="$HOME/node.socket"
-export preDir="$HOME/code/snapbrillia/quadraticvoting/testnet2"
+export preDir="$HOME/code/snapbrillia/quadraticvoting/testnet"
 export cli="cardano-cli"
 export qvf="qvf-cli"
 # export qvf="cabal run qvf-cli --"
 # ========================================== #
 
+export scriptLabel="qvf"
+export fileNamesJSONFile="$preDir/fileNames.json"
+touch $fileNamesJSONFile
+echo "{ \"ocfnTokenNameHex\"      : \"$preDir/token-name.hex\""              > $fileNamesJSONFile
+echo ", \"ocfnGovernanceMinter\"  : \"$preDir/governance-policy.plutus\""   >> $fileNamesJSONFile
+echo ", \"ocfnGovernanceSymbol\"  : \"$preDir/governance-policy.symbol\""   >> $fileNamesJSONFile
+echo ", \"ocfnRegistrationMinter\": \"$preDir/registration-policy.plutus\"" >> $fileNamesJSONFile
+echo ", \"ocfnRegistrationSymbol\": \"$preDir/registration-policy.symbol\"" >> $fileNamesJSONFile
+echo ", \"ocfnDonationMinter\"    : \"$preDir/donation-policy.plutus\""     >> $fileNamesJSONFile
+echo ", \"ocfnDonationSymbol\"    : \"$preDir/donation-policy.symbol\""     >> $fileNamesJSONFile
+echo ", \"ocfnQVFMainValidator\"  : \"$preDir/$scriptLabel.plutus\""        >> $fileNamesJSONFile
+echo ", \"ocfnContractAddress\"   : \"$preDir/$scriptLabel.addr\""          >> $fileNamesJSONFile
+echo ", \"ocfnQVFGovernanceUTxO\" : \"$preDir/gov.utxo\""                   >> $fileNamesJSONFile
+echo ", \"ocfnDeadlineSlot\"      : \"$preDir/deadline.slot\""              >> $fileNamesJSONFile
+echo ", \"ocfnUnitRedeemer\"      : \"$preDir/unit.redeemer\""              >> $fileNamesJSONFile
+echo ", \"ocfnInitialDatum\"      : \"$preDir/initial.datum\""              >> $fileNamesJSONFile
+echo "}" >> $fileNamesJSONFile
+getFileName() {
+  cat $fileNamesJSONFile | jq .$1
+}
+export scriptPlutusFile=$(getFileName ocfnQVFMainValidator)
+export scriptAddressFile=$(getFileName ocfnContractAddress)
+export govSymFile=$(getFileName ocfnGovernanceSymbol)
+export govSym=$(cat $govSymFile)
+export tokenNameHexFile=$(getFileName ocfnTokenNameHex)
+export govScriptFile=$(getFileName ocfnGovernanceMinter)
+export govUTxOFile=$(getFileName ocfnQVFGovernanceUTxO)
+export deadlineSlotFile=$(getFileName ocfnDeadlineSlot)
 export keyHolder="keyHolder"
 export keyHoldersAddress=$(cat "$preDir/$keyHolder.addr")
 export keyHoldersPubKeyHash=$(cat "$preDir/$keyHolder.pkh")
 export keyHoldersSigningKeyFile="$preDir/$keyHolder.skey"
-export scriptLabel="qvf"
-export scriptPlutusFile="$preDir/$scriptLabel.plutus"
-export scriptAddressFile="$preDir/$scriptLabel.addr"
-export policyIdFile="$preDir/$scriptLabel.symbol"
-export policyId=$(cat $policyIdFile)
-export tokenNameHexFile="$preDir/token.hex"
-export policyScriptFile="$preDir/minting.plutus"
-export authAssetUTxOFile="$preDir/authAsset.utxo"
-export deadlineSlotFile="$preDir/deadline.slot"
 export latestInteractionSlotFile="$preDir/latestInteraction.slot"
 export protocolsFile="$preDir/protocol.json"
 export txBody="$preDir/tx.unsigned"
@@ -110,18 +129,18 @@ plutus_script_to_address() {
 #
 # This function has builtin safety to prevent rewrites and wallet loss.
 #
-# For now, the maximum number of generated wallets is capped at 100.
+# For now, the maximum number of generated wallets is capped at 100000.
 # 
 # Takes 2 arguments:
 #   1. Starting number,
 #   2. Ending number.
 generate_wallets_from_to() {
 
-    max_amt=100
+    max_amt=100000
 
     if [ `expr $2 - $1` -ge $max_amt ]
     then
-    echo "That's over 100 wallets generated. Please reconsider. Edit fn if you really want to."
+    echo "That's over 100,000 wallets generated. Please reconsider. Edit fn if you really want to."
     else
 
     # Important part

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -3,14 +3,10 @@
 . scripts/env.sh
 
 startingWallet=1
-endingWallet=20
-totalLovelaceToDistribute=4000000000
+endingWallet=50000
+totalLovelaceToDistribute=5000000000000 # 100 ADA per wallet.
 
-tokenName="QVF"
-deadline=1663701377000
-
-# Storing the hex format of the token name:
-$qvf string-to-hex $tokenName $tokenNameHexFile
+deadline=1667642400000
 
 tokenNameHex=$(cat $tokenNameHexFile)
 

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -8,7 +8,7 @@ totalLovelaceToDistribute=4000000000 # 200 ADA per wallet.
 
 deadline=1667642400000
 
-tokenNameHex=$(cat $tokenNameHexFile)
+tokenNameHex=""
 govSym=""
 
 
@@ -54,24 +54,65 @@ initiate_fund() {
   # {{{
   currentSlot=$(get_newest_slot)
 
+  # GENERATING SCRIPTS
+  # {{{
+  genesisUTxO=$(get_first_utxo_of $keyHolder)
+  echo $genesisUTxO > $govUTxOFile
+
   # Generating the validation script, minting script, and some other files:
-  $qvf generate scripts                 \
-    $keyHoldersPubKeyHash               \
-    $genesisUTxO                        \
-    $currentSlot                        \
-    $deadline                           \
-    $(cat $fileNamesJSONFile | jq -c .)
-  
+  $qvf generate scripts                   \
+    $keyHoldersPubKeyHash                 \
+    $genesisUTxO                          \
+    $currentSlot                          \
+    $deadline                             \
+    "$(cat $fileNamesJSONFile | jq -c .)"
+  # }}}
+
+  # SUBMITING THE INITIAL TRANSACTION
+  # {{{
+  tokenNameHex=$(cat $tokenNameHexFile)
+  # 
   scriptAddr=$(get_script_address)
+
+  deadlineSlot=$(cat $deadlineSlotFile) 
+  cappedSlot=$(cap_deadline_slot $deadlineSlot)
+
+  deadlineDatum=$(getFileName ocfnDeadlineDatum)
+  govDatumFile=$(getFileName ocfnInitialGovDatum)
+  govAsset=$(get_gov_asset)
+  govLovelaces=1500000 #  1.5 ADA
+  firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"
+
+  generate_protocol_params
+
+  # Transaction to mint 2 governance tokens, and include 1 in two UTxOs
+  # produced at the script address. Minter expects the deadline UTxO
+  # to be produced first.
+  $cli $BUILD_TX_CONST_ARGS                   \
+    --tx-in $genesisUTxO                      \
+    --tx-in-collateral $genesisUTxO           \
+    --tx-out "$firstUTxO"                     \
+    --tx-out-inline-datum-file $deadlineDatum \
+    --tx-out "$firstUTxO"                     \
+    --tx-out-inline-datum-file $govDatumFile  \
+    --invalid-hereafter $cappedSlot           \
+    --mint "2 $govAsset"                      \
+    --mint-script-file $govScriptFile         \
+    --mint-redeemer-value 0                   \
+    --change-address $keyHoldersAddress
+  
+  sign_tx_by $keyHoldersSigningKeyFile
+  submit_tx
+  # }}}
+
+  store_current_slot
+  wait_for_new_slot
 
   # STORING SCRIPTS ON-CHAIN #
   # {{{
-  # Since the key holder wallet is going to hold a single UTxO after the
-  # distribution, we can get the first UTxO of the wallet address and use
-  # it as the genesis UTxO:
   spendingUTxO=$(get_first_utxo_of $keyHolder)
-  scriptLovelaces=15000000 # 15.0 ADA
-  scriptUTxO="$scriptAddr + $scriptLovelaces lovelace"
+  scriptLovelaces=60000000 # 60.0 ADA
+  scriptUTxO="$referenceWalletAddress+$scriptLovelaces"
 
   generate_protocol_params
 
@@ -89,11 +130,14 @@ initiate_fund() {
   store_current_slot
   wait_for_new_slot
 
-  # At this point there is only one UTxO sitting at the script address:
-  qvfRefUTxO=$(get_first_utxo_of $scriptAddr)
+  # At this point there is only one UTxO sitting at the reference wallet:
+  qvfRefUTxO=$(get_first_utxo_of $referenceWallet)
 
   # So should be the case with key holder's wallet:
   spendingUTxO=$(get_first_utxo_of $keyHolder)
+
+  scriptLovelaces=30000000 # 60.0 ADA
+  scriptUTxO="$referenceWalletAddress+$scriptLovelaces"
 
   generate_protocol_params
 
@@ -113,52 +157,20 @@ initiate_fund() {
   store_current_slot
   wait_for_new_slot
 
-  regRefUTxO=$(get_first_utxo_of $scriptAddr)
+  regRefUTxO=$(get_first_utxo_of $referenceWallet)
   if [ $regRefUTxO == $qvfRefUTxO ]; then
-    regRefUTxO=$(get_nth_utxo_of $scriptAddr 2)
-    donRefUTxO=$(get_nth_utxo_of $scriptAddr 3)
+    regRefUTxO=$(get_nth_utxo_of $referenceWallet 2)
+    donRefUTxO=$(get_nth_utxo_of $referenceWallet 3)
   else
-    donRefUTxO=$(get_nth_utxo_of $scriptAddr 2)
+    donRefUTxO=$(get_nth_utxo_of $referenceWallet 2)
   fi
-  # }}}
 
   echo $qvfRefUTxO > $qvfRefUTxOFile
   echo $regRefUTxO > $regRefUTxOFile
   echo $donRefUTxO > $donRefUTxOFile
-
-  genesisUTxO=$(get_first_utxo_of $keyHolder)
-
-  echo $genesisUTxO > $govUTxOFile
-
-  deadlineDatum=$(getFileName ocfnDeadlineDatum)
-  govDatum=$(getFileName ocfnInitialGovDatum)
-  deadlineSlot=$(cat $deadlineSlotFile) 
-  govAsset=$(get_gov_asset)
-
-  govLovelaces=1500000 #  1.5 ADA
-  firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"
-
-  generate_protocol_params
-
-  # Transaction to mint 2 governance tokens, and include 1 in two UTxOs
-  # produced at the script address. Minter expects the deadline UTxO
-  # to be produced first.
-  $cli $BUILD_TX_CONST_ARGS                   \
-    --tx-in $genesisUTxO                      \
-    --tx-in-collateral $genesisUTxO           \
-    --tx-out "$firstUTxO"                     \
-    --tx-out-inline-datum-file $deadlineDatum \
-    --tx-out "$firstUTxO"                     \
-    --tx-out-inline-datum-file $govDatum      \
-    --invalid-hereafter $deadlineSlot         \
-    --mint "2 $govAsset"                      \
-    --mint-script-file $govScriptFile         \
-    --mint-redeemer-file $unitRedeemer        \
-    --change-address $keyHoldersAddress
-  
-  sign_tx_by $keyHoldersSigningKeyFile
-  submit_tx
+  # }}}
 
   store_current_slot
+
   # }}}
 }

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -87,7 +87,7 @@ update_contract() {
     deadlineArg=$6
   fi
 
-  args='--tx-in '$utxoFromDonor' --tx-in-collateral '$utxoFromDonor' --tx-in '$utxoAtScript' --tx-in-datum-file '$currDatum' --tx-in-script-file '$scriptPlutusFile' --tx-in-redeemer-file '$action' --tx-out "'$scriptAddr' + '$newLovelace' lovelace + 1 '$authAsset'" --tx-out-datum-embed-file '$updatedDatum' '$5' --change-address '$changeAddress' '$deadlineArg' --protocol-params-file '$protocolsFile' --cddl-format '$requiredSigner' --out-file '$txBody
+  args='--tx-in '$utxoFromDonor' --tx-in-collateral '$utxoFromDonor' --tx-in '$utxoAtScript' --tx-in-datum-file '$currDatum' --tx-in-script-file '$mainScriptFile' --tx-in-redeemer-file '$action' --tx-out "'$scriptAddr' + '$newLovelace' lovelace + 1 '$authAsset'" --tx-out-datum-embed-file '$updatedDatum' '$5' --change-address '$changeAddress' '$deadlineArg' --protocol-params-file '$protocolsFile' --cddl-format '$requiredSigner' --out-file '$txBody
 
   echo $args
   # echo $donorAddrFile

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -70,9 +70,7 @@ update_contract() {
   utxoAtScript=$(remove_quotes $utxo)
   changeAddress=$(cat $donorAddrFile)
   deadlineSlot=$(cat $deadlineSlotFile)
-  currentSlot=$($cli query tip $MAGIC | jq '.slot|tonumber')
-  currentSlotPlusFiveHundred=$(expr $currentSlot + 500)
-  correctSlot=$(( $deadlineSlot < $currentSlotPlusFiveHundred ? $deadlineSlot : $currentSlotPlusFiveHundred ))
+  correctSlot=$(cap_deadline_slot $deadlineSlot)
   deadlineArg="$invalidAfter $correctSlot"
   if [ ! -z "$3" ]; then
     changeAddress=$3


### PR DESCRIPTION
The `initiate_fund` bash function now performs correctly. These are the steps it takes:
1. Picks the first UTxO from the key holder's wallet and stores it in a file,
2. Uses said UTxO to generate and store all the consecutive scripts, along with all the other files offered by `qvf-cli` (initial datums, script address, etc.),
3. Submits a transaction which consumes this UTxO, and produces 2 UTxOs at the script address: one with a deadline datum, the other with a datum that tracks the number of registered projects,
4. In the next transaction, the key holder produces a UTxO at another empty wallet (called `referenceWallet`), which carries the main validator script,
5. In another similar transaction, two UTxOs get produced at the reference wallet: one carrying the registration policy script, and the other carrying the donation policy script,
6. The resulting UTxOs (sitting at this reference wallet) are stored in respective files for future referencing.

So far, due to the sizes of the scripts, 120 ADA gets locked along with the scripts at the reference wallet. These Lovelaces can be spent and recollected.