### PR TITLE
Split the Authentication Token Name in Two

### DIFF
--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -77,7 +77,8 @@ import           Data.DonationInfo
 import           Data.Redeemer
 import           Data.RegistrationInfo
 import qualified Minter.Governance                    as Gov
-import           Minter.Governance                    ( qvfTokenName )
+import           Minter.Governance                    ( qvfTokenName
+                                                      , deadlineTokenName )
 import qualified Minter.Registration
 import           Utils
 -- }}}
@@ -447,7 +448,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
     canRegisterOrDonate :: () -> Bool
     canRegisterOrDonate _ =
       -- {{{
-      case getDatumFromRefX qvfSymbol qvfTokenName of
+      case getDatumFromRefX qvfSymbol deadlineTokenName of
         DeadlineDatum dl ->
           traceIfFalse "This funding round is over." $ deadlineNotReached dl
         _                ->
@@ -461,7 +462,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
     canFoldOrDistribute :: () -> Bool
     canFoldOrDistribute _ =
       -- {{{
-      case getDatumFromRefX qvfSymbol qvfTokenName of
+      case getDatumFromRefX qvfSymbol deadlineTokenName of
         DeadlineDatum dl ->
           traceIfFalse "This funding round is still in progress." $ deadlineReached dl
         _                ->
@@ -551,11 +552,11 @@ mkQVFValidator QVFParams{..} datum action ctx =
            (deadlineReached newDl)
       && traceIfFalse
            "Missing authentication asset."
-           (currUTxOHasX qvfSymbol qvfTokenName)
+           (currUTxOHasX qvfSymbol deadlineTokenName)
       && validateSingleOutput
            Nothing
            (Just $ DeadlineDatum newDl)
-           (Just (qvfSymbol, qvfTokenName))
+           (Just (qvfSymbol, deadlineTokenName))
       -- }}}
 
     (RegisteredProjectsCount _                    , RegisterProject        ) ->

--- a/qvf-cli/app/CLI.hs
+++ b/qvf-cli/app/CLI.hs
@@ -252,14 +252,14 @@ main =
         (    "Generate the compiled Plutus validation and minting scripts.\n\n"
 
           ++ "\tThe JSON for file names should have these fields:\n\n"
-          ++ "\t\t{ ocfnTokenNameHex       :: String\n"
-          ++ "\t\t, ocfnGovernanceMinter   :: String\n"
-          ++ "\t\t, ocfnRegistrationMinter :: String\n"
-          ++ "\t\t, ocfnDonationMinter     :: String\n"
-          ++ "\t\t, ocfnQVFMainValidator   :: String\n"
-          ++ "\t\t, ocfnDeadlineSlot       :: String\n"
-          ++ "\t\t, ocfnDeadlineDatum      :: String\n"
-          ++ "\t\t, ocfnInitialGovDatum    :: String\n"
+          ++ "\t\t{ ocfnDeadlineTokenNameHex :: String\n"
+          ++ "\t\t, ocfnGovernanceMinter     :: String\n"
+          ++ "\t\t, ocfnRegistrationMinter   :: String\n"
+          ++ "\t\t, ocfnDonationMinter       :: String\n"
+          ++ "\t\t, ocfnQVFMainValidator     :: String\n"
+          ++ "\t\t, ocfnDeadlineSlot         :: String\n"
+          ++ "\t\t, ocfnDeadlineDatum        :: String\n"
+          ++ "\t\t, ocfnInitialGovDatum      :: String\n"
           ++ "\t\t}"
         )
         "generate scripts"
@@ -478,7 +478,7 @@ main =
               regSymbol  = Reg.registrationSymbol qvfSymbol
               donSymbol  = Don.donationSymbol regSymbol
 
-          writeTokenNameHex ocfnTokenNameHex Gov.qvfTokenName
+          writeTokenNameHex ocfnDeadlineTokenNameHex Gov.deadlineTokenName
 
           dlSlot <- getDeadlineSlot currSlot dl
           govRes <- writeMintingPolicy govOF $ Gov.qvfPolicy txRef dl
@@ -589,14 +589,14 @@ instance Show OutputPlutus where
 
 
 data OffChainFileNames = OffChainFileNames
-  { ocfnTokenNameHex       :: String
-  , ocfnGovernanceMinter   :: String
-  , ocfnRegistrationMinter :: String
-  , ocfnDonationMinter     :: String
-  , ocfnQVFMainValidator   :: String
-  , ocfnDeadlineSlot       :: String
-  , ocfnDeadlineDatum      :: String
-  , ocfnInitialGovDatum    :: String
+  { ocfnDeadlineTokenNameHex :: String
+  , ocfnGovernanceMinter     :: String
+  , ocfnRegistrationMinter   :: String
+  , ocfnDonationMinter       :: String
+  , ocfnQVFMainValidator     :: String
+  , ocfnDeadlineSlot         :: String
+  , ocfnDeadlineDatum        :: String
+  , ocfnInitialGovDatum      :: String
   } deriving (Generic, A.ToJSON, A.FromJSON)
 
 


### PR DESCRIPTION
To simplify the off-chain transaction construction, the authentication asset for the deadline UTxO, now has a different token name compared to the UTxO which keeps the record of registered projects (the main asset).

Additionally, the main asset now has an empty token name.

Another change, is the attachment of a minimal value as an inline datum to the minting script reference UTxOs for a more robust and convenient distinction between the two.