### PR TITLE
Optimization Measures to Accommodate Plutus

### DIFF
--- a/quadraticVoting/src/Data/Redeemer.hs
+++ b/quadraticVoting/src/Data/Redeemer.hs
@@ -64,6 +64,7 @@ data QVFAction
   | UnlockEscrowFor       PubKeyHash Integer
   | WithdrawBounty        PubKeyHash
   | ConcludeProject
+  | Dev
 
 PlutusTx.makeIsDataIndexed ''QVFAction
   [ ('UpdateDeadline     , 0)
@@ -76,6 +77,7 @@ PlutusTx.makeIsDataIndexed ''QVFAction
   , ('UnlockEscrowFor    , 7)
   , ('WithdrawBounty     , 8)
   , ('ConcludeProject    , 9)
+  , ('Dev                , 10)
   ]
 -- }}}
 

--- a/quadraticVoting/src/Minter/Donation.hs
+++ b/quadraticVoting/src/Minter/Donation.hs
@@ -94,7 +94,7 @@ mkDonationPolicy sym action ctx =
         filterVAndValidateP :: TxOut -> Bool
         filterVAndValidateP =
           -- {{{
-          filterXAndValidateGov
+          utxoHasXOrValidGov
             ownSym
             tn
             sym

--- a/quadraticVoting/src/Minter/Donation.hs
+++ b/quadraticVoting/src/Minter/Donation.hs
@@ -117,7 +117,21 @@ mkDonationPolicy sym action ctx =
       && traceIfFalse
            "Donor's signature is required."
            (txSignedBy info diDonor)
-      && outputSAndVArePresent
+      && ( case outputs of
+             [s, v]    ->
+               -- {{{
+               outputSAndVAreValid s v
+               -- }}}
+             [_, s, v] ->
+               -- {{{
+               outputSAndVAreValid s v
+               -- }}}
+             _              ->
+               -- {{{
+               traceError
+                 "There should be exactly 1 project, and 1 donation UTxOs produced."
+               -- }}}
+         )
       -- }}}
     FoldDonations projectId          ->
       -- {{{

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -105,11 +105,11 @@ mkQVFPolicy oref deadline dlTN tn _ ctx =
     validateTwoOutputs o0 o1 =
       -- {{{
          traceIfFalse
-           "Missing governance token in the deadline UTxO."
-           (utxoHasX ownSym (Just dlTN) o0)
+           "Invalid value for the deadline UTxO."
+           (utxoHasOnlyXWithLovelaces ownSym dlTN governanceLovelaces o0)
       && traceIfFalse
-           "Missing governance token in the main UTxO."
-           (utxoHasX ownSym (Just tn) o1)
+           "Invalid value for the main UTxO."
+           (utxoHasOnlyXWithLovelaces ownSym tn governanceLovelaces o1)
       && ( case (getInlineDatum o0, getInlineDatum o1) of
              (DeadlineDatum dl, RegisteredProjectsCount count) ->
                -- {{{
@@ -119,12 +119,6 @@ mkQVFPolicy oref deadline dlTN tn _ ctx =
                && traceIfFalse
                     "Funding round must start with 0 registered projects."
                     (count == 0)
-               && traceIfFalse
-                    "Deadline UTxO must carry the required Lovelaces."
-                    (utxoHasLovelaces governanceLovelaces o0)
-               && traceIfFalse
-                    "Governance UTxO must carry the required Lovelaces."
-                    (utxoHasLovelaces governanceLovelaces o1)
                -- }}}
              _                                                 ->
                -- {{{

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -53,11 +53,16 @@ mkQVFPolicy :: TxOutRef
             -> POSIXTime
             -> TokenName
             -> TokenName
-            -> BuiltinData
+            -> Integer
             -> ScriptContext
             -> Bool
-mkQVFPolicy oref deadline dlTN tn _ ctx =
+mkQVFPolicy oref deadline dlTN tn r ctx =
   -- {{{
+  -- For development. TODO: REMOVE.
+  if r == 1 then
+    True
+  else
+  ---------------------------------
   let
     info :: TxInfo
     info = scriptContextTxInfo ctx
@@ -215,7 +220,7 @@ qvfPolicy :: TxOutRef -> POSIXTime -> MintingPolicy
 qvfPolicy oref deadline =
   -- {{{
   let
-    wrap :: (BuiltinData -> ScriptContext -> Bool) -> PSU.V2.UntypedMintingPolicy
+    wrap :: (Integer -> ScriptContext -> Bool) -> PSU.V2.UntypedMintingPolicy
     wrap = PSU.V2.mkUntypedMintingPolicy
   in
   Plutonomy.optimizeUPLC $ mkMintingPolicyScript $

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -98,7 +98,7 @@ mkQVFPolicy oref deadline dlTN tn _ ctx =
           -- }}}
         _              ->
           -- {{{
-          traceError "Exactly 1 type of asset must be minted."
+          traceError "Exactly 2 type of assets must be minted."
           -- }}}
       -- }}}
 
@@ -132,15 +132,15 @@ mkQVFPolicy oref deadline dlTN tn _ ctx =
     validOutputsPresent =
       -- {{{
       case txInfoOutputs info of
-        [o0, o1]     ->
+        [o0, o1]    ->
           -- {{{
           validateTwoOutputs o0 o1
           -- }}}
-        [ch, o0, o1] ->
+        [_, o0, o1] ->
           -- {{{
-          utxoHasOnlyAda' ch && validateTwoOutputs o0 o1
+          validateTwoOutputs o0 o1
           -- }}}
-        _            ->
+        _           ->
           -- {{{
           traceError "The 2 minted tokens must be split among 2 UTxOs."
           -- }}}

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -138,15 +138,15 @@ mkQVFPolicy oref deadline dlTN tn _ ctx =
     validOutputsPresent =
       -- {{{
       case txInfoOutputs info of
-        [o0, o1]    ->
+        [o0, o1]     ->
           -- {{{
           validateTwoOutputs o0 o1
           -- }}}
-        [_, o0, o1] ->
+        [ch, o0, o1] ->
           -- {{{
-          validateTwoOutputs o0 o1
+          utxoHasOnlyAda' ch && validateTwoOutputs o0 o1
           -- }}}
-        _           ->
+        _            ->
           -- {{{
           traceError "The 2 minted tokens must be split among 2 UTxOs."
           -- }}}

--- a/quadraticVoting/src/Minter/Registration.hs
+++ b/quadraticVoting/src/Minter/Registration.hs
@@ -221,6 +221,7 @@ mkRegistrationPolicy sym tn action ctx =
       -- }}}
   -- }}}
 
+
 -- TEMPLATE HASKELL, BOILERPLATE, ETC. 
 -- {{{
 registrationPolicy :: CurrencySymbol -> MintingPolicy

--- a/quadraticVoting/src/Minter/Registration.hs
+++ b/quadraticVoting/src/Minter/Registration.hs
@@ -93,69 +93,76 @@ mkRegistrationPolicy sym tn action ctx =
               -- }}}
           -- }}}
 
-        -- | Raises exception upon failure (full description at the `Utils`
-        --   module).
-        filterPsAndValidateS :: TxOut -> Bool
-        filterPsAndValidateS =
-          -- {{{
-          filterXAndValidateGov
-            ownSym
-            currTN
-            sym
-            tn
-            originAddr
-            (RegisteredProjectsCount $ currPCount + 1)
-          -- }}}
-
-        -- | Validates the presence of 2 output project UTxOs: one for storing
-        --   project's static information, and the other to keep a record of
-        --   the number of donations the project will receive.
-        --
-        --   Output governance UTxO gets validated by the filtering function,
-        --   but its presence is expected at the head of the filtered list.
+        -- | Checks if the given UTxOs carry project's assets, and makes sure
+        --   the first one has a `ProjectInfo` datum, while the second one has
+        --   a `ReceivedDonationsCount` attached. Also expects each of them to
+        --   carry exactly half of the registration fee Lovelaces.
         --
         --   Raises exception on @False@.
-        outputSAndPsArePresent :: Bool
-        outputSAndPsArePresent =
+        outputPsAreValid :: TxOut -> TxOut -> Bool
+        outputPsAreValid p0 p1 =
           -- {{{
-          case filter filterPsAndValidateS (txInfoOutputs info) of
-            -- TODO: Is it OK to expect a certain order for these outputs?
-            --       This is desired to prevent higher transaction fees.
-            [_, p0, p1] ->
-              -- {{{
-                 traceIfFalse
-                   "First project output must carry its static info."
-                   ( utxosDatumMatchesWith
-                       (ProjectInfo riProjectDetails)
-                       p0
-                   )
-              && traceIfFalse
-                   "Second project output must carry its record of donations."
-                   ( utxosDatumMatchesWith
-                       (ReceivedDonationsCount 0)
-                       p1
-                   )
-              && traceIfFalse
-                   "Half of the registration fee should be stored in project's reference UTxO."
-                   (utxoHasLovelaces halfOfTheRegistrationFee p0)
-              && traceIfFalse
-                   "Half of the registration fee should be stored in project's main UTxO."
-                   (utxoHasLovelaces halfOfTheRegistrationFee p1)
-              -- }}}
-            _           ->
-              -- {{{
-              traceError
-                "There should be exactly 1 governance, and 2 project UTxOs produced."
-              -- }}}
-        -- }}}
+             traceIfFalse
+               "Missing project asset in its static info UTxO."
+               (utxoHasX ownSym currTN p0)
+          && traceIfFalse
+               "Missing project asset in its state UTxO."
+               (utxoHasX ownSym currTN p1)
+          && traceIfFalse
+               "First project output must carry its static info."
+               (utxosDatumMatchesWith (ProjectInfo riProjectDetails) p0)
+          && traceIfFalse
+               "Second project output must carry its record of donations."
+               (utxosDatumMatchesWith (ReceivedDonationsCount 0) p1)
+          && traceIfFalse
+               "Half of the registration fee should be stored in project's reference UTxO."
+               (utxoHasLovelaces halfOfTheRegistrationFee p0)
+          && traceIfFalse
+               "Half of the registration fee should be stored in project's main UTxO."
+               (utxoHasLovelaces halfOfTheRegistrationFee p1)
+          -- }}}
+
+        -- | Aside from validating the project outputs, it also validates that
+        --   the produced governance UTxO is sent back to its origin, and that
+        --   it has a properly updated datum attached.
+        --
+        --   Raises exception on @False@.
+        outputSAndPsAreValid :: TxOut -> TxOut -> TxOut -> Bool
+        outputSAndPsAreValid s p0 p1 =
+          -- {{{
+             outputPsAreValid p0 p1
+          && traceIfFalse
+               "The first UTxO produced at the script address must be the governance UTxO."
+               ( validateGovUTxO
+                   sym
+                   tn
+                   originAddr
+                   (RegisteredProjectsCount $ currPCount + 1)
+                   s
+               )
+          -- }}}
       in
-         outputSAndPsArePresent
-      && traceIfFalse
+         traceIfFalse
            "Specified UTxO must be consumed."
            (utxoIsGettingSpent inputs riTxOutRef)
       && traceIfFalse
            "Project owner's signature is required."
            (txSignedBy info $ pdPubKeyHash riProjectDetails)
+      && ( case outputs of
+             [s, p0, p1]     ->
+               -- {{{
+               outputSAndPsAreValid s p0 p1
+               -- }}}
+             [ch, s, p0, p1] ->
+               -- {{{
+               utxoHasOnlyAda' ch && outputSAndPsAreValid s p0 p1
+               -- }}}
+             _               ->
+               -- {{{
+               traceError
+                 "There should be exactly 1 governance, and 2 project UTxOs produced."
+               -- }}}
+         )
       -- }}}
     ConcludeAndRefund projectId          ->
       -- {{{
@@ -163,42 +170,47 @@ mkRegistrationPolicy sym tn action ctx =
         currTN :: TokenName
         currTN = TokenName projectId
 
-        inputPsAreValid =
-          case filter (utxoHasX ownSym (Just currTN) . txInInfoResolved) inputs of
-            [TxInInfo{txInInfoResolved = p0}, TxInInfo{txInInfoResolved = p1}] ->
+        validateInputs TxInInfo{txInInfoResolved = p0} TxInInfo{txInInfoResolved = p1} =
+          -- {{{
+          case getInlineDatum p0 of
+            ProjectInfo ProjectDetails{..} ->
               -- {{{
-              case getInlineDatum p0 of
-                ProjectInfo ProjectDetails{..} ->
+              case getInlineDatum p1 of
+                Escrow _                                 ->
                   -- {{{
-                  case getInlineDatum p1 of
-                    Escrow _                                 ->
-                      -- {{{
-                         traceIfFalse
-                           "Escrow must be depleted before refunding the registration fee."
-                           ( lovelaceFromValue (txOutValue p1)
-                             == halfOfTheRegistrationFee
-                           )
-                      && traceIfFalse
-                           "Transaction must be signed by the project owner."
-                           (txSignedBy info pdPubKeyHash)
-                      -- }}}
-                    _                                        ->
-                      -- {{{
-                      traceError "Invalid datum for the second project input."
-                      -- }}}
+                     traceIfFalse
+                       "Escrow must be depleted before refunding the registration fee."
+                       ( lovelaceFromValue (txOutValue p1)
+                         == halfOfTheRegistrationFee
+                       )
+                  && traceIfFalse
+                       "Transaction must be signed by the project owner."
+                       (txSignedBy info pdPubKeyHash)
                   -- }}}
-                _                              ->
+                _                                        ->
                   -- {{{
-                  traceError "First project input must be the info UTxO."
+                  traceError "Invalid datum for the second project input."
                   -- }}}
               -- }}}
-            _        ->
+            _                              ->
               -- {{{
-              traceError "Exactly 2 project inputs are expected."
+              traceError "First project input must be the info UTxO."
               -- }}}
+          -- }}}
       in
-      inputPsAreValid
-      -- traceError "TODO."
+      case inputs of
+        [i0, i1]                                  ->
+          -- {{{
+          validateInputs i0 i1
+          -- }}}
+        [TxInInfo{txInInfoResolved = ch}, i0, i1] ->
+          -- {{{
+          utxoHasOnlyAda' ch && validateInputs i0 i1
+          -- }}}
+        _                                         ->
+          -- {{{
+          traceError "Exactly 2 project inputs are expected."
+          -- }}}
       -- }}}
   -- }}}
 

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -917,6 +917,9 @@ mkQVFValidator QVFParams{..} datum action ctx =
       projectMintIsPresent False
       -- }}}
 
+    (_                                            , Dev                    ) ->
+      -- For development. TODO: REMOVE.
+      True
     (_                                            , _                      ) ->
       traceError "Invalid transaction."
   -- }}}

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -138,8 +138,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
       -- }}}
 
     -- | Checks for key holder's signature. Induced laziness.
-    signedByKeyHolder :: () -> Bool
-    signedByKeyHolder _ =
+    signedByKeyHolder :: Bool
+    signedByKeyHolder =
       -- {{{
       traceIfFalse "Unauthorized." $ txSignedBy info qvfKeyHolder
       -- }}}
@@ -257,8 +257,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
           && traceIfFalse
                "Project output must preserve its Lovelaces."
                (utxoHasLovelaces halfOfTheRegistrationFee op)
-          && canFoldOrDistribute ()
-          && signedByKeyHolder ()
+          && canFoldOrDistribute
+          && signedByKeyHolder
           -- }}}
         _                  ->
           -- {{{
@@ -397,8 +397,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
     --   is still in progress.
     --
     --   Raises exception on @False@.
-    canRegisterOrDonate :: () -> Bool
-    canRegisterOrDonate _ =
+    canRegisterOrDonate :: Bool
+    canRegisterOrDonate =
       -- {{{
       case getDatumFromRefX qvfSymbol deadlineTokenName of
         DeadlineDatum dl ->
@@ -411,8 +411,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
     --   has ended.
     --
     --   Raises exception on @False@.
-    canFoldOrDistribute :: () -> Bool
-    canFoldOrDistribute _ =
+    canFoldOrDistribute :: Bool
+    canFoldOrDistribute =
       -- {{{
       case getDatumFromRefX qvfSymbol deadlineTokenName of
         DeadlineDatum dl ->
@@ -498,7 +498,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
   case (datum, action) of
     (DeadlineDatum _                              , UpdateDeadline newDl   ) ->
       -- {{{
-         signedByKeyHolder ()
+         signedByKeyHolder
       && traceIfFalse
            "New deadline has already passed."
            (deadlineReached newDl)
@@ -514,7 +514,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
     (RegisteredProjectsCount _                    , RegisterProject        ) ->
       -- Project Registration
       -- {{{
-      projectMintIsPresent True && canRegisterOrDonate ()
+      projectMintIsPresent True && canRegisterOrDonate
       -- }}}
 
     (ReceivedDonationsCount _                     , DonateToProject donInfo) ->
@@ -526,7 +526,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
          traceIfFalse
            "There should be exactly 1 donation asset minted."
            (mintIsPresent qvfDonationSymbol tn 1)
-      && canRegisterOrDonate ()
+      && canRegisterOrDonate
       -- }}}
 
     (Donation _                                   , FoldDonations          ) ->
@@ -561,8 +561,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
            traceIfFalse
              "All donation assets must be burnt."
              (mintIsPresent qvfDonationSymbol tn (negate tot))
-        && canFoldOrDistribute ()
-        && signedByKeyHolder ()
+        && canFoldOrDistribute
+        && signedByKeyHolder
       else
         -- Folding should happen in two phases.
         foldDonationsPhaseOne
@@ -587,8 +587,8 @@ mkQVFValidator QVFParams{..} datum action ctx =
            traceIfFalse
              "All donation assets must be burnt."
              (mintIsPresent qvfDonationSymbol tn (negate tot))
-        && canFoldOrDistribute ()
-        && signedByKeyHolder ()
+        && canFoldOrDistribute
+        && signedByKeyHolder
       else
         let
           expected  = min remaining maxDonationInputsForPhaseOne

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -189,7 +189,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
     getDatumFromRefX :: CurrencySymbol -> TokenName -> QVFDatum
     getDatumFromRefX sym tn =
       -- {{{
-      case find (utxoHasOnlyX sym (Just tn) . txInInfoResolved) (txInfoReferenceInputs info) of
+      case find (utxoHasX sym (Just tn) . txInInfoResolved) (txInfoReferenceInputs info) of
         Just txIn ->
           -- {{{
           getInlineDatum (txInInfoResolved txIn)

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -271,6 +271,25 @@ utxoHasOnlyXWithLovelaces sym tn lovelaces =
   -- }}}
 
 
+{-# INLINABLE utxoHasOnlyX #-}
+-- | Checks if a given UTxO has *only* 1 of asset X, and some Lovelaces.
+utxoHasOnlyX :: CurrencySymbol
+             -> TokenName
+             -> TxOut
+             -> Bool
+utxoHasOnlyX sym tn =
+  -- {{{
+    ( \case
+        [(sym', tn', amt'), _] ->
+          sym' == sym && tn' == tn && amt' == 1
+        _                      ->
+          False
+    )
+  . flattenValue
+  . txOutValue
+  -- }}}
+
+
 {-# INLINABLE utxoHasX #-}
 -- | Checks if a given UTxO has exactly 1 of asset X.
 utxoHasX :: CurrencySymbol -> Maybe TokenName -> TxOut -> Bool

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -216,36 +216,6 @@ validateGovUTxO govVal origAddr updatedDatum utxo =
   -- }}}
 
 
-{-# INLINABLE utxoHasXOrValidGov #-}
--- | Meant to be used as a filtering function to allow outpus carrying singular
---   governance and X assets to pass through.
---
---   Raises exception if it finds a governance token which is getting sent to
---   a different address than where it's coming from, or doesn't have a
---   properly updated datum.
-utxoHasXOrValidGov :: CurrencySymbol
-                   -> TokenName
-                   -> CurrencySymbol
-                   -> TokenName
-                   -> Address
-                   -> QVFDatum
-                   -> TxOut
-                   -> Bool
-utxoHasXOrValidGov xSym xTN govSym govTN origAddr updatedDatum utxo =
-  -- {{{
-  -- Is the UTxO carrying an X token?
-  if utxoHasX xSym (Just xTN) utxo then
-    -- {{{
-    True
-    -- }}}
-  -- Or is it a UTxO carrying the governance asset?
-  else
-    -- {{{
-    validateGovUTxO govSym govTN origAddr updatedDatum utxo
-    -- }}}
-  -- }}}
-
-
 {-# INLINABLE utxosDatumMatchesWith #-}
 -- | Checks if a UTxO carries a specific inline datum.
 --

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -261,11 +261,8 @@ utxoHasOnlyXWithLovelaces :: CurrencySymbol
 utxoHasOnlyXWithLovelaces sym tn lovelaces =
   -- {{{
     ( \case
-        [(_, _, amt), (sym', tn', amt')] ->
-             amt  == lovelaces
-          && sym' == sym
-          && tn'  == tn
-          && amt' == 1
+        [(sym', tn', amt'), (_, _, amt)] ->
+          amt == lovelaces && sym' == sym && tn' == tn && amt' == 1
         _                                ->
           False
     )
@@ -301,27 +298,6 @@ utxoHasLovelaces :: Integer -> TxOut -> Bool
 utxoHasLovelaces lovelaces txOut =
   -- {{{
   Ada.fromValue (txOutValue txOut) == Ada.lovelaceOf lovelaces
-  -- }}}
-
-
-{-# INLINABLE utxoHasOnlyAda #-}
--- | Checks if a UTxO carries any other tokens than Lovelaces..
-utxoHasOnlyAda :: TxOut -> Bool
-utxoHasOnlyAda TxOut{txOutValue = val} =
-  -- {{{
-  case flattenValue val of
-    [_] -> True
-    _   -> False
-  -- }}}
-
-
-{-# INLINABLE utxoHasOnlyAda' #-}
--- | Alternate version that raises exception upon @False@. Meant for change
---   outputs.
-utxoHasOnlyAda' :: TxOut -> Bool
-utxoHasOnlyAda' =
-  -- {{{
-  traceIfFalse "Change output can't have any tokens." . utxoHasOnlyAda
   -- }}}
 
 

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -211,22 +211,22 @@ validateGovUTxO govSym govTN origAddr updatedDatum utxo =
   -- }}}
 
 
-{-# INLINABLE filterXAndValidateGov #-}
--- | Meant to be used a filtering function to allow outpus carrying singular
+{-# INLINABLE utxoHasXOrValidGov #-}
+-- | Meant to be used as a filtering function to allow outpus carrying singular
 --   governance and X assets to pass through.
 --
 --   Raises exception if it finds a governance token which is getting sent to
 --   a different address than where it's coming from, or doesn't have a
 --   properly updated datum.
-filterXAndValidateGov :: CurrencySymbol
-                      -> TokenName
-                      -> CurrencySymbol
-                      -> TokenName
-                      -> Address
-                      -> QVFDatum
-                      -> TxOut
-                      -> Bool
-filterXAndValidateGov xSym xTN govSym govTN origAddr updatedDatum utxo =
+utxoHasXOrValidGov :: CurrencySymbol
+                   -> TokenName
+                   -> CurrencySymbol
+                   -> TokenName
+                   -> Address
+                   -> QVFDatum
+                   -> TxOut
+                   -> Bool
+utxoHasXOrValidGov xSym xTN govSym govTN origAddr updatedDatum utxo =
   -- {{{
   -- Is the UTxO carrying an X token?
   if utxoHasX xSym (Just xTN) utxo then
@@ -294,6 +294,27 @@ utxoHasLovelaces :: Integer -> TxOut -> Bool
 utxoHasLovelaces lovelaces txOut =
   -- {{{
   Ada.fromValue (txOutValue txOut) == Ada.lovelaceOf lovelaces
+  -- }}}
+
+
+{-# INLINABLE utxoHasOnlyAda #-}
+-- | Checks if a UTxO carries any other tokens than Lovelaces..
+utxoHasOnlyAda :: TxOut -> Bool
+utxoHasOnlyAda TxOut{txOutValue = val} =
+  -- {{{
+  case flattenValue val of
+    [_] -> True
+    _   -> False
+  -- }}}
+
+
+{-# INLINABLE utxoHasOnlyAda' #-}
+-- | Alternate version that raises exception upon @False@. Meant for change
+--   outputs.
+utxoHasOnlyAda' :: TxOut -> Bool
+utxoHasOnlyAda' =
+  -- {{{
+  traceIfFalse "Change output can't have any tokens." . utxoHasOnlyAda
   -- }}}
 
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -117,11 +117,19 @@ store_current_slot() {
 
 wait_for_new_slot() {
   latest=$(cat $latestInteractionSlotFile)
-  current=$($cli query tip $MAGIC | jq '.slot|tonumber')
+  current=$(get_current_slot)
+  echo -e "\nWaiting for chain extension..."
+  i=1
+  sp='///---\\\|||'
   while [ $current -eq $latest ]; do
-    current=$($cli query tip $MAGIC | jq '.slot|tonumber')
+    printf "\b${sp:i++%${#sp}:1}"
+    current=$(get_current_slot)
   done
-  echo $current
+  echo
+  echo    "----------- CHAIN EXTENDED -----------"
+  echo    "Latest interaction slot:      $latest"
+  echo    "Current slot after extension: $current"
+  echo -e "--------------------------------------\n"
 }
 
 
@@ -262,6 +270,8 @@ tidy_up_wallet() {
   $cli $BUILD_TX_CONST_ARGS $inputs --change-address $addr
   sign_tx_by $preDir/$1.skey
   submit_tx
+  store_current_slot
+  wait_for_new_slot
 }
 
 

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -141,7 +141,7 @@ initiate_fund() {
   # So should be the case with key holder's wallet:
   spendingUTxO=$(get_first_utxo_of $keyHolder)
 
-  scriptLovelaces=30000000 # 30.0 ADA
+  scriptLovelaces=32000000 # 32.0 ADA
   scriptUTxO="$referenceWalletAddress+$scriptLovelaces"
 
   generate_protocol_params


### PR DESCRIPTION
Some testing showed that it seems Plutus Core code generated by somewhat complex Plutus codes results in errors related to exhaustion of resource budgets.

The purpose of this pull request is to address this issue by imposing stricter transaction input/output patterns to avoid using higher order functions such as `filter`, and refactor on-chain scripts so that they simply expect some predefined orders for input/output UTxOs.