### PR TITLE
Off-Chain Implementation for Project/Grant Registration

### DIFF
--- a/quadraticVoting/quadraticVoting.cabal
+++ b/quadraticVoting/quadraticVoting.cabal
@@ -41,6 +41,7 @@ library
                      , plutus-script-utils
                      , plutus-tx-plugin
                      , plutus-tx
+                     , serialise
 
   ghc-options:         -Wall 
                        -fobject-code

--- a/quadraticVoting/src/Minter/Donation.hs
+++ b/quadraticVoting/src/Minter/Donation.hs
@@ -15,7 +15,6 @@
 
 module Minter.Donation where
 
-import           Ledger                               ( scriptCurrencySymbol )
 import qualified Plutonomy
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
 import           Plutus.V2.Ledger.Api
@@ -227,8 +226,8 @@ donationPolicy sym =
   -- }}}
 
 
-donationSymbol :: CurrencySymbol -> CurrencySymbol
-donationSymbol = scriptCurrencySymbol . donationPolicy
+-- donationSymbol :: CurrencySymbol -> CurrencySymbol
+-- donationSymbol = scriptCurrencySymbol . donationPolicy
 -- }}}
 
 

--- a/quadraticVoting/src/Minter/Donation.hs
+++ b/quadraticVoting/src/Minter/Donation.hs
@@ -33,10 +33,12 @@ import           Utils
 data DonationRedeemer
   = DonateToProject DonationInfo
   | FoldDonations   BuiltinByteString -- ^ Project's identifier
+  | Dev
 
 PlutusTx.makeIsDataIndexed ''DonationRedeemer
   [ ('DonateToProject ,0)
   , ('FoldDonations   ,1)
+  , ('Dev             ,10)
   ]
 -- }}}
 
@@ -206,6 +208,9 @@ mkDonationPolicy sym action ctx =
             "Project UTxO must carry the proper datum to allow burning of its donation tokens."
           -- }}}
       -- }}}
+    -- TODO: REMOVE.
+    Dev                              ->
+      True
   -- }}}
 
 

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -24,7 +24,6 @@ module Minter.Governance where
 
 -- IMPORTS
 -- {{{
-import           Ledger                               ( scriptCurrencySymbol )
 import           Ledger.Value as Value                ( flattenValue )
 import qualified Plutonomy
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
@@ -236,7 +235,9 @@ qvfPolicy oref deadline =
   -- }}}
 
 
-qvfSymbol :: TxOutRef -> POSIXTime -> CurrencySymbol
-qvfSymbol oref deadline = scriptCurrencySymbol $ qvfPolicy oref deadline
+-- TODO: Commented out as it seems to generate a different symbol compared to
+--       the one computed by `Cardano.Api`.
+-- qvfSymbol :: TxOutRef -> POSIXTime -> CurrencySymbol
+-- qvfSymbol oref deadline = scriptCurrencySymbol $ qvfPolicy oref deadline
 
 

--- a/quadraticVoting/src/Minter/Governance.hs
+++ b/quadraticVoting/src/Minter/Governance.hs
@@ -47,171 +47,182 @@ deadlineTokenName :: TokenName
 deadlineTokenName = TokenName "D"
 
 
+data TempRedeemer
+  = Validate
+  | Dev
+
+PlutusTx.makeIsDataIndexed ''TempRedeemer
+  [ ('Validate, 11)
+  , ('Dev     , 10)
+  ]
+
+
 {-# INLINABLE mkQVFPolicy #-}
 mkQVFPolicy :: TxOutRef
             -> POSIXTime
             -> TokenName
             -> TokenName
-            -> Integer
+            -> TempRedeemer
             -> ScriptContext
             -> Bool
 mkQVFPolicy oref deadline dlTN tn r ctx =
   -- {{{
   -- For development. TODO: REMOVE.
-  if r == 1 then
-    True
-  else
+  case r of
+    Dev ->
+      True
+    _   ->
   ---------------------------------
-  let
-    info :: TxInfo
-    info = scriptContextTxInfo ctx
+      let
+        info :: TxInfo
+        info = scriptContextTxInfo ctx
 
-    ownSym :: CurrencySymbol
-    ownSym = ownCurrencySymbol ctx
+        ownSym :: CurrencySymbol
+        ownSym = ownCurrencySymbol ctx
 
-    hasUTxO :: Bool
-    hasUTxO =
-      -- {{{
-      utxoIsGettingSpent (txInfoInputs info) oref
-      -- }}}
+        hasUTxO :: Bool
+        hasUTxO =
+          -- {{{
+          utxoIsGettingSpent (txInfoInputs info) oref
+          -- }}}
 
-    deadlineIsValid :: Bool
-    deadlineIsValid =
-      -- {{{
-      Interval.to deadline `Interval.contains` txInfoValidRange info
-      -- }}}
+        deadlineIsValid :: Bool
+        deadlineIsValid =
+          -- {{{
+          Interval.to deadline `Interval.contains` txInfoValidRange info
+          -- }}}
 
-    checkMintedAmount :: Bool
-    checkMintedAmount =
-      -- {{{
-      case flattenValue (txInfoMint info) of
-        [(_, dlTN', dlAmt'), (_, tn', amt')] ->
+        checkMintedAmount :: Bool
+        checkMintedAmount =
+          -- {{{
+          case flattenValue (txInfoMint info) of
+            [(_, dlTN', dlAmt'), (_, tn', amt')] ->
+              -- {{{
+                 traceIfFalse
+                   "Bad deadline token name."
+                   (dlTN' == dlTN)
+              && traceIfFalse
+                   "Bad main token name."
+                   (tn' == tn)
+              && traceIfFalse
+                   "Exactly 1 deadline token must be minted."
+                   (dlAmt' == 1)
+              && traceIfFalse
+                   "Exactly 1 main token must be minted"
+                   (amt' == 1)
+              -- }}}
+            _              ->
+              -- {{{
+              traceError "Exactly 2 type of assets must be minted."
+              -- }}}
+          -- }}}
+
+        validateTwoOutputs o0 o1 =
           -- {{{
              traceIfFalse
-               "Bad deadline token name."
-               (dlTN' == dlTN)
+               "Invalid value for the deadline UTxO."
+               (utxoHasOnlyXWithLovelaces ownSym dlTN governanceLovelaces o0)
           && traceIfFalse
-               "Bad main token name."
-               (tn' == tn)
-          && traceIfFalse
-               "Exactly 1 deadline token must be minted."
-               (dlAmt' == 1)
-          && traceIfFalse
-               "Exactly 1 main token must be minted"
-               (amt' == 1)
+               "Invalid value for the main UTxO."
+               (utxoHasOnlyXWithLovelaces ownSym tn governanceLovelaces o1)
+          && ( case (getInlineDatum o0, getInlineDatum o1) of
+                 (DeadlineDatum dl, RegisteredProjectsCount count) ->
+                   -- {{{
+                      traceIfFalse
+                        "Deadline must match with the provided parameter."
+                        (dl == deadline)
+                   && traceIfFalse
+                        "Funding round must start with 0 registered projects."
+                        (count == 0)
+                   -- }}}
+                 _                                                 ->
+                   -- {{{
+                   traceError
+                     "Either invalid datums produced, or produced in wrong order."
+                   -- }}}
+             )
           -- }}}
-        _              ->
-          -- {{{
-          traceError "Exactly 2 type of assets must be minted."
-          -- }}}
-      -- }}}
 
-    validateTwoOutputs o0 o1 =
-      -- {{{
-         traceIfFalse
-           "Invalid value for the deadline UTxO."
-           (utxoHasOnlyXWithLovelaces ownSym dlTN governanceLovelaces o0)
-      && traceIfFalse
-           "Invalid value for the main UTxO."
-           (utxoHasOnlyXWithLovelaces ownSym tn governanceLovelaces o1)
-      && ( case (getInlineDatum o0, getInlineDatum o1) of
-             (DeadlineDatum dl, RegisteredProjectsCount count) ->
-               -- {{{
-                  traceIfFalse
-                    "Deadline must match with the provided parameter."
-                    (dl == deadline)
-               && traceIfFalse
-                    "Funding round must start with 0 registered projects."
-                    (count == 0)
-               -- }}}
-             _                                                 ->
-               -- {{{
-               traceError
-                 "Either invalid datums produced, or produced in wrong order."
-               -- }}}
-         )
-      -- }}}
+        validOutputsPresent :: Bool
+        validOutputsPresent =
+          -- {{{
+          case txInfoOutputs info of
+            [o0, o1]    ->
+              -- {{{
+              validateTwoOutputs o0 o1
+              -- }}}
+            [_, o0, o1] ->
+              -- {{{
+              validateTwoOutputs o0 o1
+              -- }}}
+            _           ->
+              -- {{{
+              traceError "The 2 minted tokens must be split among 2 UTxOs."
+              -- }}}
+          -- }}}
 
-    validOutputsPresent :: Bool
-    validOutputsPresent =
-      -- {{{
-      case txInfoOutputs info of
-        [o0, o1]    ->
-          -- {{{
-          validateTwoOutputs o0 o1
-          -- }}}
-        [_, o0, o1] ->
-          -- {{{
-          validateTwoOutputs o0 o1
-          -- }}}
-        _           ->
-          -- {{{
-          traceError "The 2 minted tokens must be split among 2 UTxOs."
-          -- }}}
-      -- }}}
-
-    -- validDeadlineOutput :: Bool
-    -- validMainOutput     :: Bool
-    -- (validDeadlineOutput, validMainOutput) =
-    --   -- {{{
-    --   let
-    --     go []            acc                     = acc
-    --     go (utxo : rest) acc@(dlFound, rpcFound) =
-    --       if utxoHasX ownSym (Just tn) utxo then
-    --         -- {{{
-    --         if dlFound then
-    --           -- {{{
-    --           case getInlineDatum utxo of
-    --             RegisteredProjectsCount count ->
-    --               -- {{{
-    --               ( dlFound
-    --               ,    traceIfFalse
-    --                      "Funding round must start with 0 registered projects."
-    --                      (count == 0)
-    --                 && traceIfFalse
-    --                      "Governance UTxO must carry the required Lovelaces."
-    --                      (utxoHasLovelaces governanceLovelaces utxo)
-    --               )
-    --               -- }}}
-    --             _                             ->
-    --               -- {{{
-    --               traceError "Invalid datum for the second UTxO."
-    --               -- }}}
-    --           -- }}}
-    --         else
-    --           -- {{{
-    --           case getInlineDatum utxo of
-    --             DeadlineDatum dl ->
-    --               -- {{{
-    --               let
-    --                 cond =
-    --                      traceIfFalse
-    --                        "Deadline must match with the provided parameter."
-    --                        (dl == deadline)
-    --                   && traceIfFalse
-    --                        "Deadline UTxO must carry the required Lovelaces."
-    --                        (utxoHasLovelaces governanceLovelaces utxo)
-    --               in
-    --               go rest (cond, rpcFound)
-    --               -- }}}
-    --             _                ->
-    --               -- {{{
-    --               traceError "Deadline UTxO must be produced first."
-    --               -- }}}
-    --           -- }}}
-    --         -- }}}
-    --       else
-    --         -- {{{
-    --         go rest acc
-    --         -- }}}
-    --   in
-    --   go (txInfoOutputs info) (False, False)
-    --   -- }}}
-  in
-     traceIfFalse "UTxO not consumed." hasUTxO
-  && traceIfFalse "Deadline has passed." deadlineIsValid
-  && checkMintedAmount
-  && validOutputsPresent
+        -- validDeadlineOutput :: Bool
+        -- validMainOutput     :: Bool
+        -- (validDeadlineOutput, validMainOutput) =
+        --   -- {{{
+        --   let
+        --     go []            acc                     = acc
+        --     go (utxo : rest) acc@(dlFound, rpcFound) =
+        --       if utxoHasX ownSym (Just tn) utxo then
+        --         -- {{{
+        --         if dlFound then
+        --           -- {{{
+        --           case getInlineDatum utxo of
+        --             RegisteredProjectsCount count ->
+        --               -- {{{
+        --               ( dlFound
+        --               ,    traceIfFalse
+        --                      "Funding round must start with 0 registered projects."
+        --                      (count == 0)
+        --                 && traceIfFalse
+        --                      "Governance UTxO must carry the required Lovelaces."
+        --                      (utxoHasLovelaces governanceLovelaces utxo)
+        --               )
+        --               -- }}}
+        --             _                             ->
+        --               -- {{{
+        --               traceError "Invalid datum for the second UTxO."
+        --               -- }}}
+        --           -- }}}
+        --         else
+        --           -- {{{
+        --           case getInlineDatum utxo of
+        --             DeadlineDatum dl ->
+        --               -- {{{
+        --               let
+        --                 cond =
+        --                      traceIfFalse
+        --                        "Deadline must match with the provided parameter."
+        --                        (dl == deadline)
+        --                   && traceIfFalse
+        --                        "Deadline UTxO must carry the required Lovelaces."
+        --                        (utxoHasLovelaces governanceLovelaces utxo)
+        --               in
+        --               go rest (cond, rpcFound)
+        --               -- }}}
+        --             _                ->
+        --               -- {{{
+        --               traceError "Deadline UTxO must be produced first."
+        --               -- }}}
+        --           -- }}}
+        --         -- }}}
+        --       else
+        --         -- {{{
+        --         go rest acc
+        --         -- }}}
+        --   in
+        --   go (txInfoOutputs info) (False, False)
+        --   -- }}}
+      in
+         traceIfFalse "UTxO not consumed." hasUTxO
+      && traceIfFalse "Deadline has passed." deadlineIsValid
+      && checkMintedAmount
+      && validOutputsPresent
   -- }}}
 
 
@@ -219,7 +230,7 @@ qvfPolicy :: TxOutRef -> POSIXTime -> MintingPolicy
 qvfPolicy oref deadline =
   -- {{{
   let
-    wrap :: (Integer -> ScriptContext -> Bool) -> PSU.V2.UntypedMintingPolicy
+    wrap :: (TempRedeemer -> ScriptContext -> Bool) -> PSU.V2.UntypedMintingPolicy
     wrap = PSU.V2.mkUntypedMintingPolicy
   in
   Plutonomy.optimizeUPLC $ mkMintingPolicyScript $

--- a/quadraticVoting/src/Minter/Registration.hs
+++ b/quadraticVoting/src/Minter/Registration.hs
@@ -34,10 +34,12 @@ import           Utils
 data RegistrationRedeemer
   = RegisterProject RegistrationInfo
   | ConcludeAndRefund BuiltinByteString
+  | Dev
 
 PlutusTx.makeIsDataIndexed ''RegistrationRedeemer
   [ ('RegisterProject  , 0)
   , ('ConcludeAndRefund, 1)
+  , ('Dev              , 10)
   ]
 -- }}}
 
@@ -218,6 +220,9 @@ mkRegistrationPolicy sym tn action ctx =
           traceError "Exactly 2 project inputs are expected."
           -- }}}
       -- }}}
+    -- TODO: REMOVE.
+    Dev                                  ->
+      True
   -- }}}
 
 

--- a/quadraticVoting/src/Minter/Registration.hs
+++ b/quadraticVoting/src/Minter/Registration.hs
@@ -16,7 +16,6 @@
 module Minter.Registration where
 
 
-import           Ledger                               ( scriptCurrencySymbol )
 import qualified Plutonomy
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
 import           Plutus.V2.Ledger.Api
@@ -241,7 +240,7 @@ registrationPolicy sym =
   -- }}}
 
 
-registrationSymbol :: CurrencySymbol -> CurrencySymbol
-registrationSymbol = scriptCurrencySymbol . registrationPolicy
+-- registrationSymbol :: CurrencySymbol -> CurrencySymbol
+-- registrationSymbol = scriptCurrencySymbol . registrationPolicy
 -- }}}
 -- }}}

--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -91,7 +91,16 @@ data QVFParams = QVFParams
   , qvfSymbol         :: CurrencySymbol
   , qvfProjectSymbol  :: CurrencySymbol
   , qvfDonationSymbol :: CurrencySymbol
-  } deriving (Show)
+  }
+
+instance Show QVFParams where
+  show QVFParams{..} =
+         "QVFParams"
+    P.++ "\n  { qvfKeyHolder      = " P.++ show qvfKeyHolder
+    P.++ "\n  , qvfSymbol         = " P.++ show qvfSymbol
+    P.++ "\n  , qvfProjectSymbol  = " P.++ show qvfProjectSymbol
+    P.++ "\n  , qvfDonationSymbol = " P.++ show qvfDonationSymbol
+    P.++ "\n  }"
 
 PlutusTx.makeLift ''QVFParams
 -- }}}
@@ -157,12 +166,10 @@ mkQVFValidator QVFParams{..} datum action ctx =
     getTokenNameOfUTxO sym utxo =
       -- {{{
       case flattenValue (txOutValue utxo) of
-        [(sym', tn', amt'), (sym'', tn'', amt'')] ->
+        [(sym', tn', amt'), _] ->
           -- {{{
           if sym' == sym && amt' == 1 then
             Just tn'
-          else if sym'' == sym && amt'' == 1 then
-            Just tn''
           else
             Nothing
           -- }}}

--- a/quadraticVoting/src/Utils.hs
+++ b/quadraticVoting/src/Utils.hs
@@ -169,19 +169,15 @@ getInputGovernanceUTxOFrom :: CurrencySymbol
                            -> TxOut
 getInputGovernanceUTxOFrom sym tn inputs =
   -- {{{
-  case inputs of
-    txIn : _ ->
+  case find (utxoHasOnlyX sym tn . txInInfoResolved) inputs of
+    Just txIn ->
       -- {{{
-      if utxoHasX sym (Just tn) $ txInInfoResolved txIn then
-        txInInfoResolved txIn
-      else
-        traceError
-          "The first inputs must carry the governance asset of the context."
+      txInInfoResolved txIn
       -- }}}
-    _        ->
+    Nothing   ->
       -- {{{
       traceError
-        "Zero inputs (impossible)."
+        "Governance asset missing."
       -- }}}
   -- }}}
 

--- a/qvf-cli/app/CLI.hs
+++ b/qvf-cli/app/CLI.hs
@@ -167,8 +167,9 @@ hexStringToByteString str =
         'f' -> Just 15
         _   -> Nothing
       -- }}}
-    go []                (_, soFar)     = Just $ LBS.pack soFar
-    go (currChar : rest) (mPrev, soFar) =
+    go []                (Just _, soFar) = Nothing
+    go []                (_, soFar)      = Just $ LBS.pack soFar
+    go (currChar : rest) (mPrev, soFar)  =
       case mPrev of
         Just prev ->
           -- {{{

--- a/qvf-cli/app/CLI.hs
+++ b/qvf-cli/app/CLI.hs
@@ -12,7 +12,7 @@ module Main (main) where
 import Debug.Trace (trace)
 
 import           Cardano.Api
-import           Cardano.Api.Shelley        ( PlutusScript (..) )
+import           Cardano.Api.Shelley        ( PlutusScript(..) )
 import           Codec.Serialise            ( Serialise
                                             , serialise )
 import qualified Data.Aeson                 as A
@@ -70,29 +70,6 @@ scriptDataToData (ScriptDataNumber n)         =
   I n
 scriptDataToData (ScriptDataBytes bs)         =
   B bs
-  -- }}}
-
-
-scriptToCardanoApiScript :: Ledger.Script -> Script PlutusScriptV2
-scriptToCardanoApiScript =
-  -- {{{
-    PlutusScript PlutusScriptV2
-  . PlutusScriptSerialised
-  . SBS.toShort
-  . LBS.toStrict
-  . serialise
-  -- }}}
-
-
-mintingPolicyToSymbol :: Ledger.MintingPolicy -> Ledger.CurrencySymbol
-mintingPolicyToSymbol =
-  -- {{{
-    fromString
-  . BS8.unpack
-  . serialiseToRawBytesHex
-  . hashScript
-  . scriptToCardanoApiScript
-  . Ledger.getMintingPolicy
   -- }}}
 
 
@@ -633,12 +610,18 @@ main =
               --
               donPolicy = Don.donationPolicy regSymbol
               donSymbol = mintingPolicyToSymbol donPolicy
+              --
+              yellow    = "\ESC[38:5:220m"
+              red       = "\ESC[38:5:160m"
+              green     = "\ESC[38:5:77m"
+              purple    = "\ESC[38:5:127m"
+              noColor   = "\ESC[0m"
 
-          putStrLn "Gov. Symbol:"
+          putStrLn $ yellow ++ "\nGov. Symbol:"
           print govSymbol
-          putStrLn "Reg. Symbol:"
+          putStrLn $ red ++ "\nReg. Symbol:"
           print regSymbol
-          putStrLn "Don. Symbol:"
+          putStrLn $ green ++ "\nDon. Symbol:"
           print donSymbol
 
           writeTokenNameHex dlTNOF Gov.deadlineTokenName
@@ -657,8 +640,9 @@ main =
                       , OC.qvfProjectSymbol  = regSymbol
                       , OC.qvfDonationSymbol = donSymbol
                       }
-              putStrLn "QVF Parameters:"
+              putStrLn $ purple ++ "\nQVF Parameters:"
               print qvfParams
+              putStrLn noColor
               valRes <- writeValidator qvfOF $ OC.qvfValidator qvfParams
               case valRes of
                 Right _ -> do

--- a/qvf-cli/qvf-cli.cabal
+++ b/qvf-cli/qvf-cli.cabal
@@ -20,7 +20,6 @@ executable qvf-cli
 
   build-depends:       aeson
                      , base >= 4.9 && < 5
-                     , base16-bytestring
                      , bytestring
                      , cardano-api
                      , cardano-binary

--- a/qvf-cli/qvf-cli.cabal
+++ b/qvf-cli/qvf-cli.cabal
@@ -20,6 +20,7 @@ executable qvf-cli
 
   build-depends:       aeson
                      , base >= 4.9 && < 5
+                     , base16-bytestring
                      , bytestring
                      , cardano-api
                      , cardano-binary

--- a/scripts/blockfrost.sh
+++ b/scripts/blockfrost.sh
@@ -47,21 +47,21 @@ reconstruct_utxos() {
   echo $1 \
     | jq -c 'map(
       { utxo: (.tx_hash + "#" + (.tx_index|tostring))
-      , datumHash: .data_hash
+      , datum: .inline_datum
       , lovelace: (.amount | .[0] | .quantity)
       })'
 }
 
 
 # Returns a JSON array of objects, each having 3 fields:
-# `utxo`, `datumHash`, and `lovelace`. All elements of this
+# `utxo`, `datum`, and `lovelace`. All elements of this
 # array posses an authentication token.
 #
 # Takes 2 arguments:
 #   1. Script address,
 #   2. Authentication asset (policy ID plus the token name,
 #      without a `.` in between).
-bf_get_utxos_hashes_lovelaces() {
+bf_get_utxos_datums_lovelaces() {
   zero=$(bf_query_address $1)
   one=$(keep_utxos_with_asset $2 $zero)
   echo $(reconstruct_utxos $one)
@@ -72,8 +72,8 @@ bf_get_utxos_hashes_lovelaces() {
 #   1. Script address,
 #   2. Authentication asset (policy ID plus the token name,
 #      without a `.` in between).
-bf_get_first_utxo_hash_lovelaces() {
-  echo $(bf_get_utxos_hashes_lovelaces $1 $2) \
+bf_get_first_utxo_datum_lovelaces() {
+  echo $(bf_get_utxos_datums_lovelaces $1 $2) \
     | jq .[0]
 }
 
@@ -84,9 +84,9 @@ bf_get_first_utxo_hash_lovelaces() {
 #      without a `.` in between).
 #   3. Start of random range.
 #   4. End of random range.
-bf_get_random_utxo_hash_lovelaces() {
+bf_get_random_utxo_datum_lovelaces() {
   rand=$(shuf -i $3-$4 -n 1)
-  echo $(bf_get_utxos_hashes_lovelaces $1 $2) \
+  echo $(bf_get_utxos_datums_lovelaces $1 $2) \
     | jq .[$rand]
 }
 
@@ -97,24 +97,6 @@ bf_get_datum_value_from_hash() {
   curl -H                      \
     "project_id: $AUTH_ID"     \
     -s "$URL/scripts/datum/$1"
-}
-
-
-# Assumes the object format is the one returned by
-# `bf_get_utxos_hashes_lovelaces`.
-#
-# Takes 1 (or 2) argument(s):
-#   1. JSON value with the format described above.
-#   2. (Optional) Custom datum value.
-bf_add_datum_value_to_utxo() {
-  datumHash=$(echo $1 | jq -c .datumHash)
-  datumValue=""
-  if [ ! -z "$2" ]; then
-    datumValue=$(echo $2 | jq -c .)
-  else
-    datumValue=$(bf_get_datum_value_from_hash $(remove_quotes $datumHash) | jq -c .json_value)
-  fi
-  echo $1 | jq -c --arg datumValue "$datumValue" '. += {datumValue: ($datumValue | fromjson)}'
 }
 
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -30,7 +30,7 @@ remove_quotes() {
 export scriptLabel="qvf"
 export fileNamesJSONFile="$preDir/fileNames.json"
 touch $fileNamesJSONFile
-echo "{ \"ocfnPreDir\"              : \"$preDir\""                              > $fileNamesJSONFile
+echo "{ \"ocfnPreDir\"              : \"$preDir\""                      > $fileNamesJSONFile
 echo ", \"ocfnDeadlineTokenNameHex\": \"deadline-token-name.hex\""     >> $fileNamesJSONFile
 echo ", \"ocfnGovernanceMinter\"    : \"governance-policy.plutus\""    >> $fileNamesJSONFile
 echo ", \"ocfnGovernanceSymbol\"    : \"governance-policy.symbol\""    >> $fileNamesJSONFile

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -20,25 +20,32 @@ remove_quotes() {
 export scriptLabel="qvf"
 export fileNamesJSONFile="$preDir/fileNames.json"
 touch $fileNamesJSONFile
-echo "{ \"ocfnDeadlineTokenNameHex\": \"$preDir/deadline-token-name.hex\""      > $fileNamesJSONFile
-echo ", \"ocfnGovernanceMinter\"    : \"$preDir/governance-policy.plutus\""    >> $fileNamesJSONFile
-echo ", \"ocfnGovernanceSymbol\"    : \"$preDir/governance-policy.symbol\""    >> $fileNamesJSONFile
-echo ", \"ocfnQVFGovernanceUTxO\"   : \"$preDir/gov.utxo\""                    >> $fileNamesJSONFile
-echo ", \"ocfnRegistrationMinter\"  : \"$preDir/registration-policy.plutus\""  >> $fileNamesJSONFile
-echo ", \"ocfnRegistrationSymbol\"  : \"$preDir/registration-policy.symbol\""  >> $fileNamesJSONFile
-echo ", \"ocfnRegistrationRefUTxO\" : \"$preDir/registration-policy.refUTxO\"" >> $fileNamesJSONFile
-echo ", \"ocfnDonationMinter\"      : \"$preDir/donation-policy.plutus\""      >> $fileNamesJSONFile
-echo ", \"ocfnDonationSymbol\"      : \"$preDir/donation-policy.symbol\""      >> $fileNamesJSONFile
-echo ", \"ocfnDonationRefUTxO\"     : \"$preDir/donation-policy.refUTxO\""     >> $fileNamesJSONFile
-echo ", \"ocfnQVFMainValidator\"    : \"$preDir/$scriptLabel.plutus\""         >> $fileNamesJSONFile
-echo ", \"ocfnQVFRefUTxO\"          : \"$preDir/$scriptLabel.refUTxO\""        >> $fileNamesJSONFile
-echo ", \"ocfnContractAddress\"     : \"$preDir/$scriptLabel.addr\""           >> $fileNamesJSONFile
-echo ", \"ocfnDeadlineSlot\"        : \"$preDir/deadline.slot\""               >> $fileNamesJSONFile
-echo ", \"ocfnDeadlineDatum\"       : \"$preDir/deadline.govDatum\""           >> $fileNamesJSONFile
-echo ", \"ocfnInitialGovDatum\"     : \"$preDir/initial.govDatum\""            >> $fileNamesJSONFile
+echo "{ \"ocfnPreDir\"              : \"$preDir\""                              > $fileNamesJSONFile
+echo ", \"ocfnDeadlineTokenNameHex\": \"deadline-token-name.hex\""     >> $fileNamesJSONFile
+echo ", \"ocfnGovernanceMinter\"    : \"governance-policy.plutus\""    >> $fileNamesJSONFile
+echo ", \"ocfnGovernanceSymbol\"    : \"governance-policy.symbol\""    >> $fileNamesJSONFile
+echo ", \"ocfnQVFGovernanceUTxO\"   : \"gov.utxo\""                    >> $fileNamesJSONFile
+echo ", \"ocfnRegistrationMinter\"  : \"registration-policy.plutus\""  >> $fileNamesJSONFile
+echo ", \"ocfnRegistrationSymbol\"  : \"registration-policy.symbol\""  >> $fileNamesJSONFile
+echo ", \"ocfnRegistrationRefUTxO\" : \"registration-policy.refUTxO\"" >> $fileNamesJSONFile
+echo ", \"ocfnDonationMinter\"      : \"donation-policy.plutus\""      >> $fileNamesJSONFile
+echo ", \"ocfnDonationSymbol\"      : \"donation-policy.symbol\""      >> $fileNamesJSONFile
+echo ", \"ocfnDonationRefUTxO\"     : \"donation-policy.refUTxO\""     >> $fileNamesJSONFile
+echo ", \"ocfnQVFMainValidator\"    : \"$scriptLabel.plutus\""         >> $fileNamesJSONFile
+echo ", \"ocfnQVFRefUTxO\"          : \"$scriptLabel.refUTxO\""        >> $fileNamesJSONFile
+echo ", \"ocfnContractAddress\"     : \"$scriptLabel.addr\""           >> $fileNamesJSONFile
+echo ", \"ocfnDeadlineSlot\"        : \"deadline.slot\""               >> $fileNamesJSONFile
+echo ", \"ocfnDeadlineDatum\"       : \"deadline.govDatum\""           >> $fileNamesJSONFile
+echo ", \"ocfnInitialGovDatum\"     : \"initial.govDatum\""            >> $fileNamesJSONFile
+echo ", \"ocfnCurrentDatum\"        : \"current.datum\""               >> $fileNamesJSONFile
+echo ", \"ocfnUpdatedDatum\"        : \"updated.datum\""               >> $fileNamesJSONFile
+echo ", \"ocfnNewDatum\"            : \"new.datum\""                   >> $fileNamesJSONFile
+echo ", \"ocfnExtraDatum\"          : \"extra.datum\""                 >> $fileNamesJSONFile
+echo ", \"ocfnQVFRedeemer\"         : \"qvf.redeemer\""                >> $fileNamesJSONFile
+echo ", \"ocfnMinterRedeemer\"      : \"minter.redeemer\""             >> $fileNamesJSONFile
 echo "}" >> $fileNamesJSONFile
 getFileName() {
-  remove_quotes $(cat $fileNamesJSONFile | jq -c .$1)
+  echo $preDir/$(remove_quotes $(cat $fileNamesJSONFile | jq -c .$1))
 }
 # Main script:
 export mainScriptFile=$(getFileName ocfnQVFMainValidator)

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -233,10 +233,10 @@ vkey_to_public_key_hash() {
 # 
 # Doesn't take any arguments, uses global variables.
 plutus_script_to_address() {
-    $cli address build-script         \
-        $MAGIC                        \
-        --script-file $mainScriptFile \
-        --out-file $scriptAddressFile
+  $cli address build-script       \
+    $MAGIC                        \
+    --script-file $mainScriptFile \
+    --out-file $scriptAddressFile
 }
 
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -4,9 +4,18 @@ export MAGIC='--testnet-magic 2'
 export CARDANO_NODE_SOCKET_PATH="$HOME/preview-testnet/node.socket"
 export preDir="$HOME/code/quadraticvoting/testnet"
 export cli="$HOME/preview-testnet/cardano-cli"
-# export qvf="qvf-cli"
-export qvf="cabal run qvf-cli --"
+export qvf="qvf-cli"
+# export qvf="cabal run qvf-cli --"
 # ========================================== #
+
+# Removes the single quotes.
+#
+# Takes 1 argument:
+#   1. Target string.
+remove_single_quotes() {
+  echo $1           \
+  | sed 's|['"\'"',]||g'
+}
 
 # Removes the double quotes.
 #
@@ -43,6 +52,7 @@ echo ", \"ocfnNewDatum\"            : \"new.datum\""                   >> $fileN
 echo ", \"ocfnQVFRedeemer\"         : \"qvf.redeemer\""                >> $fileNamesJSONFile
 echo ", \"ocfnMinterRedeemer\"      : \"minter.redeemer\""             >> $fileNamesJSONFile
 echo ", \"ocfnProjectTokenName\"    : \"project-token-name.hex\""      >> $fileNamesJSONFile
+echo ", \"ocfnRegisteredProjects\"  : \"registered-projects.txt\""     >> $fileNamesJSONFile
 echo "}" >> $fileNamesJSONFile
 getFileName() {
   echo $preDir/$(remove_quotes $(cat $fileNamesJSONFile | jq -c .$1))
@@ -70,6 +80,8 @@ export deadlineTokenNameHexFile=$(getFileName ocfnDeadlineTokenNameHex)
 touch $deadlineTokenNameHexFile
 export projectTokenNameFile=$(getFileName ocfnProjectTokenName)
 touch $projectTokenNameFile
+export registeredProjectsFile=$(getFileName ocfnRegisteredProjects)
+touch $registeredProjectsFile
 export govUTxOFile=$(getFileName ocfnQVFGovernanceUTxO)
 export qvfRefUTxOFile=$(getFileName ocfnQVFRefUTxO)
 export regRefUTxOFile=$(getFileName ocfnRegistrationRefUTxO)

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -3,7 +3,8 @@ export MAGIC='--testnet-magic 2'
 # === CHANGE THESE VARIABLES ACCORDINGLY === #
 export CARDANO_NODE_SOCKET_PATH="$HOME/preview-testnet/node.socket"
 export preDir="$HOME/code/quadraticvoting/testnet"
-export cli="$HOME/preview-testnet/cardano-cli"
+export cli="cardano-cli"
+# export cli="$HOME/preview-testnet/cardano-cli"
 export qvf="qvf-cli"
 # export qvf="cabal run qvf-cli --"
 # ========================================== #

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -200,12 +200,12 @@ dev_depletion() {
   $cli $BUILD_TX_CONST_ARGS                                        \
     --tx-in-collateral $collateral                                 \
     --tx-in $(get_first_utxo_of $scriptLabel)                      \
-    --spending-tx-in-reference $(cat qvfRefUTxOFile)               \
+    --spending-tx-in-reference $(cat $qvfRefUTxOFile)              \
     --spending-plutus-script-v2                                    \
     --spending-reference-tx-in-inline-datum-present                \
     --spending-reference-tx-in-redeemer-file $preDir/dev.redeemer  \
     --tx-in $(get_nth_utxo_of $scriptLabel 2)                      \
-    --spending-tx-in-reference $(cat qvfRefUTxOFile)               \
+    --spending-tx-in-reference $(cat $qvfRefUTxOFile)              \
     --spending-plutus-script-v2                                    \
     --spending-reference-tx-in-inline-datum-present                \
     --spending-reference-tx-in-redeemer-file $preDir/dev.redeemer  \

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -6,7 +6,7 @@ startingWallet=1
 endingWallet=20
 totalLovelaceToDistribute=4000000000 # 200 ADA per wallet.
 
-deadline=1667642400000
+export deadline=1667642400000
 
 govSym=""
 
@@ -41,12 +41,11 @@ store_gov_symbol() {
 
 get_gov_asset() {
   store_gov_symbol
-  echo $govSym.
+  echo $govSym
 }
 
 get_deadline_asset() {
-  store_gov_symbol
-  echo $govSym.$(cat $deadlineTokenNameHexFile)
+  echo $(cat $govSymFile).$(cat $deadlineTokenNameHexFile)
 }
 
 get_script_data_hash() {
@@ -80,8 +79,10 @@ initiate_fund() {
 
   deadlineDatum=$(getFileName ocfnDeadlineDatum)
   govDatumFile=$(getFileName ocfnInitialGovDatum)
-  deadlineAsset=$(get_deadline_asset)
+  # NOTE: The order of these 2 assignments matters.
   govAsset=$(get_gov_asset)
+  deadlineAsset=$(get_deadline_asset)
+  # -----------------------------------------------
   govLovelaces=1500000 #  1.5 ADA
   firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $deadlineAsset"
   secondUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -59,14 +59,22 @@ initiate_fund() {
   done
   rm $registeredProjectsFile
   touch $registeredProjectsFile
+  echo "Getting the current slot..."
   currentSlot=$(get_newest_slot)
 
   # GENERATING SCRIPTS
   # {{{
+  echo
+  echo "Getting the UTxO to be used for finding the currency symbols..."
   genesisUTxO=$(get_first_utxo_of $keyHolder)
   echo $genesisUTxO > $govUTxOFile
+  echo
+  echo "The UTxO is:"
+  echo -e "\033[97m$genesisUTxO"
+  echo -e "\033[0m"
 
   # Generating the validation script, minting script, and some other files:
+  echo "Finding the scripts and writing them to disk..."
   $qvf generate scripts                   \
     $keyHoldersPubKeyHash                 \
     $genesisUTxO                          \
@@ -97,22 +105,24 @@ initiate_fund() {
   firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $deadlineAsset"
   secondUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"
 
+  unit="{\"constructor\":1,\"fields\":[]}"
+
   generate_protocol_params
 
   # Transaction to mint 2 governance tokens, and include 1 in two UTxOs
   # produced at the script address. Minter expects the deadline UTxO
   # to be produced first.
-  $cli $BUILD_TX_CONST_ARGS                   \
-    --tx-in $genesisUTxO                      \
-    --tx-in-collateral $genesisUTxO           \
-    --tx-out "$firstUTxO"                     \
-    --tx-out-inline-datum-file $deadlineDatum \
-    --tx-out "$secondUTxO"                    \
-    --tx-out-inline-datum-file $govDatumFile  \
-    --invalid-hereafter $cappedSlot           \
-    --mint "1 $deadlineAsset + 1 $govAsset"   \
-    --mint-script-file $govScriptFile         \
-    --mint-redeemer-value 0                   \
+  $cli $BUILD_TX_CONST_ARGS                    \
+    --tx-in $genesisUTxO                       \
+    --tx-in-collateral $genesisUTxO            \
+    --tx-out "$firstUTxO"                      \
+    --tx-out-inline-datum-file $deadlineDatum  \
+    --tx-out "$secondUTxO"                     \
+    --tx-out-inline-datum-file $govDatumFile   \
+    --invalid-hereafter $cappedSlot            \
+    --mint "1 $deadlineAsset + 1 $govAsset"    \
+    --mint-script-file $govScriptFile          \
+    --mint-redeemer-file $preDir/temp.redeemer \
     --change-address $keyHoldersAddress
   
   sign_and_submit_tx $keyHoldersSigningKeyFile
@@ -192,11 +202,18 @@ initiate_fund() {
 }
 
 
+# Takes 1 argument:
+#   1. The mint argument for `cardano-cli`.
 dev_depletion() {
   # {{{
   collateral=$(get_first_utxo_of $keyHolder)
   deadlineAsset=$(get_deadline_asset)
   govAsset=$(get_gov_asset)
+  regRefUTxO=$(cat $regRefUTxOFile)
+  regSym=$(cat $regSymFile)
+  donRefUTxO=$(cat $donRefUTxOFile)
+  donSym=$(cat $donSymFile)
+  devRedeemer="$preDir/dev.redeemer"
 
   txIn=""
   # {{{ LOOP TO FIND $txIn 
@@ -218,13 +235,20 @@ dev_depletion() {
     fi
   done
   # }}}
-
-  $cli $BUILD_TX_CONST_ARGS                         \
-    --tx-in-collateral $collateral                  \
-    $txIn                                           \
-    --mint "-1 $deadlineAsset + -1 $govAsset"       \
-    --mint-script-file $govScriptFile               \
-    --mint-redeemer-value 1                         \
+  $cli $BUILD_TX_CONST_ARGS                           \
+    --tx-in-collateral $collateral                    \
+    $txIn                                             \
+    --mint "$1"                                       \
+    --mint-script-file $govScriptFile                 \
+    --mint-redeemer-file $devRedeemer                 \
+    --mint-tx-in-reference $regRefUTxO                \
+    --mint-plutus-script-v2                           \
+    --mint-reference-tx-in-redeemer-file $devRedeemer \
+    --policy-id $regSym                               \
+    --mint-tx-in-reference $donRefUTxO                \
+    --mint-plutus-script-v2                           \
+    --mint-reference-tx-in-redeemer-file $devRedeemer \
+    --policy-id $donSym                               \
     --change-address $(cat testnet/$keyHolder.addr)
   sign_and_submit_tx $preDir/$keyHolder.skey
   wait_for_new_slot
@@ -243,14 +267,18 @@ deplete_reference_wallet() {
   # }}}
 }
 
+# Takes 1 argument:
+#   1. The mint argument for `cardano-cli`.
 dev_reset() {
-  dev_depletion
+  dev_depletion "$1"
   deplete_reference_wallet
   tidy_up_wallet $keyHolder
 }
 
+# Takes 1 argument:
+#   1. The mint argument for `cardano-cli`.
 dev_restart() {
-  dev_reset
+  dev_reset "$1"
   cabal install qvf-cli --overwrite-policy=always
   initiate_fund
 }

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -105,12 +105,10 @@ initiate_fund() {
     --mint-redeemer-value 0                   \
     --change-address $keyHoldersAddress
   
-  sign_tx_by $keyHoldersSigningKeyFile
-  submit_tx
+  sign_and_submit_tx $keyHoldersSigningKeyFile
+  wait_for_new_slot
   # }}}
 
-  store_current_slot
-  wait_for_new_slot
   store_current_slot
   wait_for_new_slot
 
@@ -130,11 +128,9 @@ initiate_fund() {
     --tx-out-reference-script-file $mainScriptFile \
     --change-address $keyHoldersAddress
 
-  sign_tx_by $keyHoldersSigningKeyFile
-  submit_tx
-
-  store_current_slot
+  sign_and_submit_tx $keyHoldersSigningKeyFile
   wait_for_new_slot
+
   store_current_slot
   wait_for_new_slot
 
@@ -161,11 +157,9 @@ initiate_fund() {
     --tx-out-inline-datum-value 1                 \
     --change-address $keyHoldersAddress
 
-  sign_tx_by $keyHoldersSigningKeyFile
-  submit_tx
-
-  store_current_slot
+  sign_and_submit_tx $keyHoldersSigningKeyFile
   wait_for_new_slot
+
   store_current_slot
   wait_for_new_slot
 
@@ -196,12 +190,12 @@ dev_depletion() {
   $cli $BUILD_TX_CONST_ARGS                                        \
     --tx-in-collateral $collateral                                 \
     --tx-in $(get_first_utxo_of $scriptLabel)                      \
-    --spending-tx-in-reference $(cat testnet/$scriptLabel.refUTxO) \
+    --spending-tx-in-reference $(cat qvfRefUTxOFile)               \
     --spending-plutus-script-v2                                    \
     --spending-reference-tx-in-inline-datum-present                \
     --spending-reference-tx-in-redeemer-file $preDir/dev.redeemer  \
     --tx-in $(get_nth_utxo_of $scriptLabel 2)                      \
-    --spending-tx-in-reference $(cat testnet/$scriptLabel.refUTxO) \
+    --spending-tx-in-reference $(cat qvfRefUTxOFile)               \
     --spending-plutus-script-v2                                    \
     --spending-reference-tx-in-inline-datum-present                \
     --spending-reference-tx-in-redeemer-file $preDir/dev.redeemer  \
@@ -209,9 +203,7 @@ dev_depletion() {
     --mint-script-file $govScriptFile                              \
     --mint-redeemer-value 1                                        \
     --change-address $(cat testnet/$keyHolder.addr)
-  sign_tx_by $preDir/$keyHolder.skey
-  submit_tx
-  store_current_slot
+  sign_and_submit_tx $preDir/$keyHolder.skey
   wait_for_new_slot
   show_utxo_tables $scriptLabel
   # }}}
@@ -222,9 +214,7 @@ deplete_reference_wallet() {
   $cli $BUILD_TX_CONST_ARGS                    \
     $(get_all_input_utxos_at $referenceWallet) \
     --change-address $keyHoldersAddress
-  sign_tx_by $preDir/$referenceWallet.skey
-  submit_tx
-  store_current_slot
+  sign_and_submit_tx $preDir/$referenceWallet.skey
   wait_for_new_slot
   show_utxo_tables $referenceWallet
   # }}}

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -54,6 +54,11 @@ get_script_data_hash() {
 
 initiate_fund() {
   # {{{
+  for proj in $(cat $registeredProjectsFile); do
+    rm $preDir/$proj
+  done
+  rm $registeredProjectsFile
+  touch $registeredProjectsFile
   currentSlot=$(get_newest_slot)
 
   # GENERATING SCRIPTS
@@ -83,6 +88,11 @@ initiate_fund() {
   govAsset=$(get_gov_asset)
   deadlineAsset=$(get_deadline_asset)
   # -----------------------------------------------
+  regSym=$($cli transaction policyid --script-file $regScriptFile)
+  echo $regSym > $regSymFile
+  donSym=$($cli transaction policyid --script-file $donScriptFile)
+  echo $donSym > $donSymFile
+
   govLovelaces=1500000 #  1.5 ADA
   firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $deadlineAsset"
   secondUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -105,8 +105,6 @@ initiate_fund() {
   firstUTxO="$scriptAddr + $govLovelaces lovelace + 1 $deadlineAsset"
   secondUTxO="$scriptAddr + $govLovelaces lovelace + 1 $govAsset"
 
-  unit="{\"constructor\":1,\"fields\":[]}"
-
   generate_protocol_params
 
   # Transaction to mint 2 governance tokens, and include 1 in two UTxOs
@@ -224,7 +222,7 @@ dev_depletion() {
   # are prefixed with "--tx-in ", we are using an extra variable ($count), to
   # handle the intermittent whitespaces.
   count=0
-  const="--spending-tx-in-reference $(cat $qvfRefUTxOFile) --spending-plutus-script-v2 --spending-reference-tx-in-inline-datum-present --spending-reference-tx-in-redeemer-file $preDir/dev.redeemer"
+  const="--spending-tx-in-reference $(cat $qvfRefUTxOFile) --spending-plutus-script-v2 --spending-reference-tx-in-inline-datum-present --spending-reference-tx-in-redeemer-file $devRedeemer"
   for i in $(get_all_input_utxos_at $scriptLabel); do
     if [ $count -eq 0 ]; then
       txIn="$txIn$i "

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -50,32 +50,6 @@ regRefUTxO=$(cat $regRefUTxOFile)
 
 generate_protocol_params
 
-args="
-  --required-signer-hash $projectOwnerPKH                   \
-  --read-only-tx-in-reference $deadlineUTxO                 \
-  --tx-in $govUTxO                                          \
-  --spending-tx-in-reference $qvfRefUTxO                    \
-  --spending-plutus-script-v2                               \
-  --spending-reference-tx-in-inline-datum-present           \
-  --spending-reference-tx-in-redeemer-file $qvfRedeemerFile \
-  --tx-in $projectIdUTxO                                    \
-  --tx-in-collateral $projectIdUTxO                         \
-  --tx-out \"$firstUTxO\"                                   \
-  --tx-out-inline-datum-file $updatedDatumFile              \
-  --tx-out \"$projUTxO\"                                    \
-  --tx-out-inline-datum-file $projectInfoDatumFile          \
-  --tx-out \"$projUTxO\"                                    \
-  --tx-out-inline-datum-file $projectDatumFile              \
-  --invalid-hereafter $cappedSlot                           \
-  --mint \"2 $projectAsset\"                                \
-  --mint-tx-in-reference $regRefUTxO                        \
-  --mint-plutus-script-v2                                   \
-  --mint-reference-tx-in-redeemer-file $minterRedeemerFile  \
-  --policy-id $regSym                                       \
-  --change-address $projectOwnerAddress"
-
-echo -e $args
-
 $cli $BUILD_TX_CONST_ARGS                                   \
   --required-signer-hash $projectOwnerPKH                   \
   --read-only-tx-in-reference $deadlineUTxO                 \

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+. scripts/env.sh
+. scripts/initiation.sh
+. scripts/blockfrost.sh
+
+qvfAddress=$(cat $scriptAddressFile)
+govAsset=$(cat $govSymFile)
+regSym=$(cat $regSymFile)
+donSym=$(cat $donSymFile)
+deadlineAsset="$govAsset$(cat $deadlineTokenNameHexFile)"
+deadlineSlot=$(cat $deadlineSlotFile)
+cappedSlot=$(cap_deadline_slot $deadlineSlot)
+
+govUTxOObj="$(bf_get_utxos_datums_lovelaces $qvfAddress $govAsset | jq -c '.[0]')"
+govUTxO=$(remove_quotes $(echo $govUTxOObj | jq -c .utxo))
+govCurrDatum="$(echo $govUTxOObj | jq -c .datum)"
+echo $govCurrDatum > $currentDatumFile
+govLovelaces=$(echo $govUTxOObj | jq -c .lovelace)
+deadlineUTxO=$(remove_quotes $(bf_get_utxos_datums_lovelaces $qvfAddress $deadlineAsset | jq -c '.[0] | .utxo'))
+
+projectOwnerWalletLabel=$1
+projectName=$2
+projectRequestedFund=$3
+projectOwnerAddress=$4
+
+projectIdUTxO=$(get_first_utxo_of $projectOwnerWalletLabel)
+projectOwnerPKH=$(cat $preDir/$projectOwnerWalletLabel.pkh)
+
+$qvf register-project       \
+  $projectIdUTxO            \
+  $projectOwnerPKH          \
+	$projectName              \
+	$projectRequestedFund     \
+  $(cat $fileNamesJSONFile)
+
+# {{{
+projectTokenName=$(cat $projectTokenNameFile)
+projectAsset="$regSym.$projectTokenName"
+projectDatumFile="$newDatumFile"
+projectInfoDatumFile="$preDir/$projectTokenName"
+
+regFeeLovelaces=1500000 # 1.5 ADA, half of the registration fee.
+firstUTxO="$qvfAddr + $govLovelaces lovelace + 1 $govAsset"
+projUTxO="$qvfAddr + $regFeeLovelaces lovelace + 1 $projectAsset"
+
+qvfRefUTxO=$(cat qvfRefUTxOFile)
+regRefUTxO=$(cat regRefUTxOFile)
+
+generate_protocol_params
+
+$cli $BUILD_TX_CONST_ARGS                                   \
+  --required-signer-hash $projectOwnerPKH                   \
+
+  --read-only-tx-in-reference $deadlineUTxO                 \
+
+  --tx-in $projectIdUTxO                                    \
+  --tx-in-collateral $projectIdUTxO                         \
+
+  --tx-in $govUTxO                                          \
+  --spending-tx-in-reference $qvfRefUTxO                    \
+  --spending-plutus-script-v2                               \
+  --spending-reference-tx-in-inline-datum-present           \
+  --spending-reference-tx-in-redeemer-file $qvfRedeemerFile \
+
+  --tx-out "$firstUTxO"                                     \
+  --tx-out-inline-datum-file $updatedDatumFile              \
+
+  --tx-out "$projUTxO"                                      \
+  --tx-out-inline-datum-file $projectInfoDatumFile          \
+
+  --tx-out "$projUTxO"                                      \
+  --tx-out-inline-datum-file $projectDatumFile              \
+
+  --invalid-hereafter $cappedSlot                           \
+
+  --mint "2 $projectAsset"                                  \
+  --mint-tx-in-reference $regRefUTxO                        \
+  --mint-plutus-script-v2                                   \
+  --mint-reference-tx-in-redeemer-file $minterRedeemerFile  \
+
+  --change-address $projectOwnerAddress
+
+sign_and_submit_tx $keyHoldersSigningKeyFile
+wait_for_new_slot
+# }}}

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -16,9 +16,8 @@ govUTxOObj="$(bf_get_utxos_datums_lovelaces $qvfAddress $govAsset | jq -c '.[0]'
 govUTxO=$(remove_quotes $(echo $govUTxOObj | jq -c .utxo))
 govCurrDatum="$(echo $govUTxOObj | jq -c .datum)"
 echo "$govCurrDatum" > $currentDatumFile
-govLovelaces=$(echo $govUTxOObj | jq -c .lovelace)
-deadlineUTxOObj="$(bf_get_utxos_datums_lovelaces $qvfAddress $deadlineAsset | jq -c '.[0]')"
-deadlineUTxO=$(remove_quotes $($cho $deadlineUTxOObj | jq -c .utxo))
+govLovelaces=$(remove_quotes $(echo $govUTxOObj | jq -c .lovelace))
+deadlineUTxO=$(remove_quotes $(bf_get_utxos_datums_lovelaces $qvfAddress $deadlineAsset | jq -c '.[0] | .utxo'))
 
 projectOwnerWalletLabel=$1
 projectName=$2
@@ -43,46 +42,64 @@ projectDatumFile="$newDatumFile"
 projectInfoDatumFile="$preDir/$projectTokenName"
 
 regFeeLovelaces=1500000 # 1.5 ADA, half of the registration fee.
-firstUTxO="$qvfAddr + $govLovelaces lovelace + 1 $govAsset"
-projUTxO="$qvfAddr + $regFeeLovelaces lovelace + 1 $projectAsset"
+firstUTxO="$qvfAddress + $govLovelaces lovelace + 1 $govAsset"
+projUTxO="$qvfAddress + $regFeeLovelaces lovelace + 1 $projectAsset"
 
 qvfRefUTxO=$(cat $qvfRefUTxOFile)
 regRefUTxO=$(cat $regRefUTxOFile)
 
 generate_protocol_params
 
-$cli $BUILD_TX_CONST_ARGS                                   \
+args="
   --required-signer-hash $projectOwnerPKH                   \
-
   --read-only-tx-in-reference $deadlineUTxO                 \
-
-  --tx-in $projectIdUTxO                                    \
-  --tx-in-collateral $projectIdUTxO                         \
-
   --tx-in $govUTxO                                          \
   --spending-tx-in-reference $qvfRefUTxO                    \
   --spending-plutus-script-v2                               \
   --spending-reference-tx-in-inline-datum-present           \
   --spending-reference-tx-in-redeemer-file $qvfRedeemerFile \
+  --tx-in $projectIdUTxO                                    \
+  --tx-in-collateral $projectIdUTxO                         \
+  --tx-out \"$firstUTxO\"                                   \
+  --tx-out-inline-datum-file $updatedDatumFile              \
+  --tx-out \"$projUTxO\"                                    \
+  --tx-out-inline-datum-file $projectInfoDatumFile          \
+  --tx-out \"$projUTxO\"                                    \
+  --tx-out-inline-datum-file $projectDatumFile              \
+  --invalid-hereafter $cappedSlot                           \
+  --mint \"2 $projectAsset\"                                \
+  --mint-tx-in-reference $regRefUTxO                        \
+  --mint-plutus-script-v2                                   \
+  --mint-reference-tx-in-redeemer-file $minterRedeemerFile  \
+  --policy-id $regSym                                       \
+  --change-address $projectOwnerAddress"
 
+echo -e $args
+
+$cli $BUILD_TX_CONST_ARGS                                   \
+  --required-signer-hash $projectOwnerPKH                   \
+  --read-only-tx-in-reference $deadlineUTxO                 \
+  --tx-in $govUTxO                                          \
+  --spending-tx-in-reference $qvfRefUTxO                    \
+  --spending-plutus-script-v2                               \
+  --spending-reference-tx-in-inline-datum-present           \
+  --spending-reference-tx-in-redeemer-file $qvfRedeemerFile \
+  --tx-in $projectIdUTxO                                    \
+  --tx-in-collateral $projectIdUTxO                         \
   --tx-out "$firstUTxO"                                     \
   --tx-out-inline-datum-file $updatedDatumFile              \
-
   --tx-out "$projUTxO"                                      \
   --tx-out-inline-datum-file $projectInfoDatumFile          \
-
   --tx-out "$projUTxO"                                      \
   --tx-out-inline-datum-file $projectDatumFile              \
-
   --invalid-hereafter $cappedSlot                           \
-
   --mint "2 $projectAsset"                                  \
   --mint-tx-in-reference $regRefUTxO                        \
   --mint-plutus-script-v2                                   \
   --mint-reference-tx-in-redeemer-file $minterRedeemerFile  \
-
+  --policy-id $regSym                                       \
   --change-address $projectOwnerAddress
 
-sign_and_submit_tx $keyHoldersSigningKeyFile
+sign_and_submit_tx $keyHoldersSigningKeyFile $preDir/$1.skey
 wait_for_new_slot
 # }}}

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -15,27 +15,29 @@ cappedSlot=$(cap_deadline_slot $deadlineSlot)
 govUTxOObj="$(bf_get_utxos_datums_lovelaces $qvfAddress $govAsset | jq -c '.[0]')"
 govUTxO=$(remove_quotes $(echo $govUTxOObj | jq -c .utxo))
 govCurrDatum="$(echo $govUTxOObj | jq -c .datum)"
-echo $govCurrDatum > $currentDatumFile
+echo "$govCurrDatum" > $currentDatumFile
 govLovelaces=$(echo $govUTxOObj | jq -c .lovelace)
-deadlineUTxO=$(remove_quotes $(bf_get_utxos_datums_lovelaces $qvfAddress $deadlineAsset | jq -c '.[0] | .utxo'))
+deadlineUTxOObj="$(bf_get_utxos_datums_lovelaces $qvfAddress $deadlineAsset | jq -c '.[0]')"
+deadlineUTxO=$(remove_quotes $($cho $deadlineUTxOObj | jq -c .utxo))
 
 projectOwnerWalletLabel=$1
 projectName=$2
 projectRequestedFund=$3
-projectOwnerAddress=$4
+projectOwnerAddress=$(cat $preDir/$projectOwnerWalletLabel.addr)
 
 projectIdUTxO=$(get_first_utxo_of $projectOwnerWalletLabel)
 projectOwnerPKH=$(cat $preDir/$projectOwnerWalletLabel.pkh)
 
-$qvf register-project       \
-  $projectIdUTxO            \
-  $projectOwnerPKH          \
-	$projectName              \
-	$projectRequestedFund     \
-  $(cat $fileNamesJSONFile)
+$qvf register-project         \
+  $projectIdUTxO              \
+  $projectOwnerPKH            \
+	$projectName                \
+	$projectRequestedFund       \
+  "$(cat $fileNamesJSONFile)"
 
 # {{{
 projectTokenName=$(cat $projectTokenNameFile)
+echo $projectTokenName >> $registeredProjectsFile
 projectAsset="$regSym.$projectTokenName"
 projectDatumFile="$newDatumFile"
 projectInfoDatumFile="$preDir/$projectTokenName"
@@ -44,8 +46,8 @@ regFeeLovelaces=1500000 # 1.5 ADA, half of the registration fee.
 firstUTxO="$qvfAddr + $govLovelaces lovelace + 1 $govAsset"
 projUTxO="$qvfAddr + $regFeeLovelaces lovelace + 1 $projectAsset"
 
-qvfRefUTxO=$(cat qvfRefUTxOFile)
-regRefUTxO=$(cat regRefUTxOFile)
+qvfRefUTxO=$(cat $qvfRefUTxOFile)
+regRefUTxO=$(cat $regRefUTxOFile)
 
 generate_protocol_params
 


### PR DESCRIPTION
Apart from implementing the bash functions, and corresponding endpoints for `qvf-cli`, this PR also fixes the issue that resulted in incorrect derivation of currency symbols from the policy scripts.

Another feature introduced here is the development endpoints (i.e. extra data constructors for the redeemers) for all the on-chain scripts. This allows us to withdraw from the contract, and also burn any of its tokens unconditionally, which prevents the loss of test Lovelaces during development.