### PR TITLE
Restrict Escrow UTxOs to Key Holder

### DIFF
--- a/quadraticVoting/src/QVF.hs
+++ b/quadraticVoting/src/QVF.hs
@@ -677,6 +677,7 @@ mkQVFValidator QVFParams{..} datum action ctx =
         currLovelaces = lovelaceFromValue $ txOutValue currUTxO
         tn            = getCurrTokenName qvfProjectSymbol
       in
+      signedByKeyHolder && -- For development. TODO: REMOVE.
       case Map.lookup winner beneficiaries of
         Just bounty ->
           -- {{{
@@ -1108,6 +1109,7 @@ distributePrize
   matchPool
   remaining
   den =
+  -- {{{
   findOutputsFromProjectUTxOs pSym pTN inputs refs $
     \inP@TxOut{txOutValue = pVal, txOutAddress = pAddr} infoUTxO ->
       case (getInlineDatum inP, getInlineDatum infoUTxO) of
@@ -1169,6 +1171,7 @@ distributePrize
           -- {{{
           traceError "E088"
           -- }}}
+  -- }}}
 -- }}}
 
 

--- a/scripts/distribute-prize.sh
+++ b/scripts/distribute-prize.sh
@@ -64,9 +64,9 @@ generate_protocol_params
 
 buildTx="$cli $BUILD_TX_CONST_ARGS
   --required-signer-hash $keyHoldersPubKeyHash
+  $refArgs $inputArgs $outputArgs
   --tx-in $keyHoldersInUTxO
   --tx-in-collateral $keyHoldersInUTxO
-  $refArgs $inputArgs $outputArgs
   --change-address $keyHoldersAddress
   "
 

--- a/scripts/eliminate-one-project.sh
+++ b/scripts/eliminate-one-project.sh
@@ -58,9 +58,9 @@ generate_protocol_params
 
 buildTx="$cli $BUILD_TX_CONST_ARGS
   --required-signer-hash $keyHoldersPubKeyHash
+  $refArgs $inputArgs $outputArgs
   --tx-in $keyHoldersInUTxO
   --tx-in-collateral $keyHoldersInUTxO
-  $refArgs $inputArgs $outputArgs
   --change-address $keyHoldersAddress
   "
 

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -90,6 +90,8 @@ $cli $BUILD_TX_CONST_ARGS                                        \
 if [ "$ENV" == "dev" ]; then
   sign_and_submit_tx $preDir/$projectOwnerWalletLabel.skey
   wait_for_new_slot
+  store_current_slot
+  wait_for_new_slot
 else
   store_current_slot
   JSON_STRING=$( jq -n                         \


### PR DESCRIPTION
Since, at this point, we're not utilizing the implemented functionality of the escrow UTxOs, leaving them open to the respective project owners (as they should be) allows project owners to simply mark those UTxOs for another one of their own wallets and easily extract all the Lovelaces.

By requiring the key holder's signature (which most of our interactions in this version already do) we can cover this security flaw.

Some of the scripts have also undergone minor changes (re-ordering of their inputs).