### PR TITLE
Turning the Deadline Milliseconds Into an Argument

### DIFF
--- a/quadraticVoting/quadraticVoting.cabal
+++ b/quadraticVoting/quadraticVoting.cabal
@@ -11,6 +11,8 @@ Author:              Andy Sizer
 Maintainer:          andysizer@snapbrillia.com
                    , https://github.com/blockchainrelativity
                    , keyanmaskoot@snapbrillia.com
+                   , https://github.com/ritterbush
+                   , szhang12341@gmail.com
                    , tasosvaltinos@snapbrillia.com
 Build-Type:          Simple
 Copyright:           © 2022 Snapbrillia

--- a/qvf-cli/qvf-cli.cabal
+++ b/qvf-cli/qvf-cli.cabal
@@ -3,11 +3,17 @@ Cabal-Version:      3.6
 Name:                qvf-cli
 Version:             0.2.2.0
 Author:              Andy Sizer
-                   , Tasos Valtinos
+                   , Curtis Myers
                    , Keyan M.
+                   , Paul Ritterbush
+                   , Shan Yu Zhang
+                   , Tasos Valtinos
 Maintainer:          andysizer@snapbrillia.com
-                   , tasosvaltinos@snapbrillia.com
+                   , https://github.com/blockchainrelativity
                    , keyanmaskoot@snapbrillia.com
+                   , https://github.com/ritterbush
+                   , szhang12341@gmail.com
+                   , tasosvaltinos@snapbrillia.com
 Build-Type:          Simple
 Copyright:           © 2022 Snapbrillia
 License:             Apache-2.0

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -43,6 +43,26 @@ remove_back_slashes() {
   # }}}
 }
 
+
+# Returns the POSIX time in milliseconds a week from now.
+#
+# Takes no arguments.
+posix_one_week_from_now() {
+  now=$(date +%s)
+  init=$(expr $now + 604800)
+  echo "$init"000
+}
+
+
+# Returns the POSIX time in milliseconds a month from now.
+#
+# Takes no arguments.
+posix_one_month_from_now() {
+  now=$(date +%s)
+  init=$(expr $now + 2628000)
+  echo "$init"000
+}
+
 export scriptLabel="qvf"
 export fileNamesJSONFile="$preDir/fileNames.json"
 # Creating the $fileNamesJSONFile:

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -16,8 +16,6 @@ startingWallet=1
 endingWallet=20
 totalLovelaceToDistribute=4000000000 # 200 ADA per wallet.
 
-export deadline=1672017020000
-
 govSym=""
 
 generate_wallets_and_distribute() {
@@ -61,6 +59,10 @@ get_script_data_hash() {
 
 initiate_fund() {
   # {{{
+  deadline=$1
+  if [ "$1" == "dev" ]; then
+    deadline=$(posix_one_month_from_now)
+  fi
   for proj in $(cat $registeredProjectsFile | jq 'map(.tn) | .[]'); do
     rm -f $preDir/$proj
   done
@@ -78,9 +80,9 @@ initiate_fund() {
   genesisUTxO=$(get_first_utxo_of $keyHolder)
   echo $genesisUTxO > $govUTxOFile
   echo
-  echo "The UTxO is:"
-  echo -e "\033[97m$genesisUTxO"
-  echo -e "\033[0m"
+  echo -e "The UTxO is:$WHITE"
+  echo "$genesisUTxO"
+  echo -e "$NO_COLOR"
 
   # Generating the validation script, minting script, and some other files:
   echo "Finding the scripts and writing them to disk..."

--- a/scripts/scenario.sh
+++ b/scripts/scenario.sh
@@ -2,7 +2,7 @@
 
 . scripts/initiation.sh
 
-initiate_fund
+initiate_fund dev
 
 . scripts/contribute.sh $keyHolder 100000000
 

--- a/scripts/scenario2.sh
+++ b/scripts/scenario2.sh
@@ -2,7 +2,7 @@
 
 . scripts/initiation.sh
 
-initiate_fund
+initiate_fund dev
 
 . scripts/register-project.sh 1 ProjectA 10000000000
 


### PR DESCRIPTION
Previously, the deadline was defined as a variable inside the initiation
script, which resulted in merge conflicts and implicit problems. This PR
aims to resolve this issue by turning the deadline into an argument
for the `initiate_fund` function.

Furthermore, two additional helper functions are defined for
convenience: `posix_one_week_from_now` and `posix_one_month_from_now`,
which return the POSIX time in milliseconds one week (and one month) from
the moment of invocation.