### PR TITLE
Separation of Setup Logic from Exposure of Utility Bash Functions

### DIFF
--- a/scripts/accumulate-prize-weights.sh
+++ b/scripts/accumulate-prize-weights.sh
@@ -2,6 +2,8 @@
 
 . $REPO/scripts/initiation.sh
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 regSym=$(cat $regSymFile)

--- a/scripts/check-if-utxo-present.sh
+++ b/scripts/check-if-utxo-present.sh
@@ -5,10 +5,10 @@ if [ -z $REPO ]; then
   echo "absolute path to this repository to \$REPO before proceeding."
   return 1
 else
-. $REPO/scripts/local-env.sh
+  . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 walletLabel=$1
 UTxOPresent=$(get_first_utxo_of $custodialWalletLabel/$walletLabel)

--- a/scripts/collateral-key-holder-sign-transaction.sh
+++ b/scripts/collateral-key-holder-sign-transaction.sh
@@ -29,7 +29,7 @@ else
   if [ "$3" = '--sign-registration-tx' ]; then 
     store_current_slot_2 $projectTokenName $scriptLabel
   elif [ "$3" = '--sign-contribution-tx' ]; then 
-    store_current $scriptLabel
+    store_current_slot $scriptLabel
   else
     store_current_slot $projectTokenName 
   fi

--- a/scripts/collateral-key-holder-sign-transaction.sh
+++ b/scripts/collateral-key-holder-sign-transaction.sh
@@ -1,11 +1,15 @@
+#!/bin/bash
+
 if [ -z $REPO ]; then
-  echo "error"
+  echo "The \$REPO environment variable is not defined. Please review the script at"
+  echo "\`scripts/local-env.sh\` and make any desired changes, and then assign the"
+  echo "absolute path to this repository to \$REPO before proceeding."
   return 1
 else
-. $REPO/scripts/local-env.sh
+  . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 transactionCBOR=$1
 projectTokenName=$2

--- a/scripts/collateral-key-holder-sign-transaction.sh
+++ b/scripts/collateral-key-holder-sign-transaction.sh
@@ -10,7 +10,7 @@ fi
 transactionCBOR=$1
 projectTokenName=$2
 
-if [ "$3" = '--sign-registration-tx' ]; then
+if [ "$3" = '--sign-registration-tx' ] || [ "$3" = '--sign-contribution-tx' ]; then
   differenceBetweenSlots=$(get_slot_difference $scriptLabel)
 else 
   differenceBetweenSlots=$(get_slot_difference $projectTokenName)
@@ -28,6 +28,8 @@ else
   echo "$JSON_STRING"
   if [ "$3" = '--sign-registration-tx' ]; then 
     store_current_slot_2 $projectTokenName $scriptLabel
+  elif [ "$3" = '--sign-contribution-tx' ]; then 
+    store_current $scriptLabel
   else
     store_current_slot $projectTokenName 
   fi

--- a/scripts/consume-bounty-credit.sh
+++ b/scripts/consume-bounty-credit.sh
@@ -16,7 +16,8 @@ projectWalletAddress=$2
 txInUTxO=$3
 txOutUTxO=$4
 
-projectTokenName=$(remove_quotes $(cat $registeredProjectsFile | jq ". [] | select(.address == \"$projectWalletAddress\") | .tn"))
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
+projectTokenName=$(cat $registeredProjectsFile | jq -r ". [] | select(.address == \"$projectWalletAddress\") | .tn")
 deadlineSlot=$(cat $deadlineSlotFile)
 cappedSlot=$(cap_deadline_slot $deadlineSlot)
 

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -23,6 +23,8 @@ if [ "$ENV" == "dev" ]; then
   changeAddress=$($preDir/$sponsorWalletLabel.addr)
 else
   contributionAmount=$1
+  collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
+  txInCollateralUTxO="--tx-in-collateral $collateralUTxO"
   if [ "$3" == "--queue" ]; then
     queue="True"
     walletLabel=$2
@@ -34,8 +36,6 @@ else
     changeAddress=$2
     txInUTxO=$3
     txOutUTxO=$4
-    collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
-    txInCollateralUTxO="--tx-in-collateral $collateralUTxO"
   fi
 fi
 

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -21,58 +21,84 @@ if [ "$ENV" == "dev" ]; then
   txInCollateralUTxO="--tx-in-collateral $sponsorInputUTxO"
   txOutUTxO=""
 else
-  sponsorAddress=$1
-  contributionAmount=$2
-  txInUTxO=$3
-  txOutUTxO=$4
-  collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
-  txInCollateralUTxO="--tx-in-collateral $collateralUTxO"
+  contributionAmount=$1
+  if [ "$3" == "--queue" ]; then
+    queue="True"
+    walletLabel=$2
+    projectOwnerAddress=$(cat $custodialWalletsDir/$walletLabel.addr)
+    projectOwnerPKH=$(cat $custodialWalletsDir/$walletLabel.pkh)
+    txInUTxO="--tx-in $(get_first_utxo_of $custodialWalletLabel/$walletLabel) --tx-in $(get_first_utxo_of $keyHolder)"
+    changeAddress=$keyHoldersAddress
+  else
+    changeAddress=$2
+    txInUTxO=$3
+    txOutUTxO=$4
+    collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
+    txInCollateralUTxO="--tx-in-collateral $collateralUTxO"
+  fi
 fi
 
-qvfAddress=$(cat $scriptAddressFile)
-govAsset=$(cat $govSymFile)
-deadlineSlot=$(cat $deadlineSlotFile)
-cappedSlot=$(cap_deadline_slot $deadlineSlot)
-
-govUTxOObj="$(get_governance_utxo)"
-govUTxO=$(remove_quotes $(echo $govUTxOObj | jq -c .utxo))
-govCurrDatum="$(echo $govUTxOObj | jq -c .datum)"
-echo "$govCurrDatum" > $currentDatumFile
-govLovelaces=$(remove_quotes $(echo $govUTxOObj | jq -c .lovelace))
-deadlineUTxO=$(remove_quotes $(get_deadline_utxo | jq -c '.utxo'))
-qvfRefUTxO=$(cat $qvfRefUTxOFile)
-newGovLovelaces=$(expr $govLovelaces + $contributionAmount)
-govOutput="$qvfAddress + $newGovLovelaces lovelace + 1 $govAsset"
-
-# Using `qvf-cli` to write the proper redeemer to disk:
-$qvf contribute               \
-  $contributionAmount         \
-  "$(cat $fileNamesJSONFile)"
-
-generate_protocol_params
-
-$cli $BUILD_TX_CONST_ARGS                                       \
-  --read-only-tx-in-reference $deadlineUTxO                     \
-  --tx-in $govUTxO                                              \
-  --spending-tx-in-reference $qvfRefUTxO                        \
-  --spending-plutus-script-v2                                   \
-  --spending-reference-tx-in-inline-datum-present               \
-  --spending-reference-tx-in-redeemer-file $qvfRedeemerFile     \
-  $txInUTxO $txInCollateralUTxO $txOutUTxO                      \
-  --tx-out "$govOutput"                                         \
-  --tx-out-inline-datum-file $currentDatumFile                  \
-  --invalid-hereafter $cappedSlot                               \
-  --change-address $sponsorAddress      
-
-if [ "$ENV" == "dev" ]; then
-  sign_and_submit_tx $preDir/$sponsorWalletLabel.skey
-  store_current_slot $scriptLabel
-  wait_for_new_slot $scriptLabel
-  store_current_slot $scriptLabel
-  wait_for_new_slot $scriptLabel
+if [ "$queue" == "True" ]; then
+  differenceBetweenSlots=$(get_slot_difference_2 $keyHolder $scriptLabel)
 else
-  JSON_STRING=$( jq -n                         \
-    --arg bn "$(cat $txBody | jq -r .cborHex)" \
-    '{transaction: $bn}' )
-  echo "--json--$JSON_STRING"
+  differenceBetweenSlots=$(get_slot_difference $scriptLabel)
+fi
+
+if [ $differenceBetweenSlots -lt 100 ]; then
+  echo "NetworkBusy"
+else 
+  qvfAddress=$(cat $scriptAddressFile)
+  govAsset=$(cat $govSymFile)
+  deadlineSlot=$(cat $deadlineSlotFile)
+  cappedSlot=$(cap_deadline_slot $deadlineSlot)
+
+  govUTxOObj="$(get_governance_utxo)"
+  govUTxO=$(remove_quotes $(echo $govUTxOObj | jq -c .utxo))
+  govCurrDatum="$(echo $govUTxOObj | jq -c .datum)"
+  echo "$govCurrDatum" > $currentDatumFile
+  govLovelaces=$(remove_quotes $(echo $govUTxOObj | jq -c .lovelace))
+  deadlineUTxO=$(remove_quotes $(get_deadline_utxo | jq -c '.utxo'))
+  qvfRefUTxO=$(cat $qvfRefUTxOFile)
+  newGovLovelaces=$(expr $govLovelaces + $contributionAmount)
+  govOutput="$qvfAddress + $newGovLovelaces lovelace + 1 $govAsset"
+
+  # Using `qvf-cli` to write the proper redeemer to disk:
+  $qvf contribute               \
+    $contributionAmount         \
+    "$(cat $fileNamesJSONFile)"
+
+  generate_protocol_params
+
+  $cli $BUILD_TX_CONST_ARGS                                       \
+    --read-only-tx-in-reference $deadlineUTxO                     \
+    --tx-in $govUTxO                                              \
+    --spending-tx-in-reference $qvfRefUTxO                        \
+    --spending-plutus-script-v2                                   \
+    --spending-reference-tx-in-inline-datum-present               \
+    --spending-reference-tx-in-redeemer-file $qvfRedeemerFile     \
+    $txInUTxO $txInCollateralUTxO $txOutUTxO                      \
+    --tx-out "$govOutput"                                         \
+    --tx-out-inline-datum-file $currentDatumFile                  \
+    --invalid-hereafter $cappedSlot                               \
+    --change-address $changeAddress      
+
+  if [ "$ENV" == "dev" ]; then
+    sign_and_submit_tx $preDir/$sponsorWalletLabel.skey
+    store_current_slot $scriptLabel
+    wait_for_new_slot $scriptLabel
+    store_current_slot $scriptLabel
+    wait_for_new_slot $scriptLabel
+  elif [ "$queue" == "True" ]; then
+      # {{{
+    sign_and_submit_tx $custodialWalletsDir/$walletLabel.skey $preDir/$collateralKeyHolder.skey $preDir/$keyHolder.skey
+    transactionHash=$($cli transaction txid --tx-file $txSigned)
+    echo "$transactionHash"
+    store_current_slot_2 $scriptLabel $keyHolder
+     # }}}
+  else
+    JSON_STRING=$( jq -n                         \
+      --arg bn "$(cat $txBody | jq -r .cborHex)" \
+      '{transaction: $bn}' )
+    echo "--json--$JSON_STRING"
+  fi
 fi

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -20,6 +20,7 @@ if [ "$ENV" == "dev" ]; then
   txInUTxO="--tx-in $sponsorInputUTxO"
   txInCollateralUTxO="--tx-in-collateral $sponsorInputUTxO"
   txOutUTxO=""
+  changeAddress=$($preDir/$sponsorWalletLabel.addr)
 else
   contributionAmount=$1
   if [ "$3" == "--queue" ]; then

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -24,8 +24,8 @@ else
   sponsorAddress=$1
   contributionAmount=$2
   txInUTxO=$3
-  txInCollateralUTxO=$4
-  txOutUTxO=$5
+  txOutUTxO=$4
+  txInCollateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
 fi
 
 qvfAddress=$(cat $scriptAddressFile)
@@ -70,7 +70,6 @@ if [ "$ENV" == "dev" ]; then
   store_current_slot $scriptLabel
   wait_for_new_slot $scriptLabel
 else
-  store_current_slot $scriptLabel
   JSON_STRING=$( jq -n                         \
     --arg bn "$(cat $txBody | jq -r .cborHex)" \
     '{transaction: $bn}' )

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -9,8 +9,9 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
 
 if [ "$ENV" == "dev" ]; then
   sponsorWalletLabel=$1

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -25,7 +25,8 @@ else
   contributionAmount=$2
   txInUTxO=$3
   txOutUTxO=$4
-  txInCollateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
+  collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
+  txInCollateralUTxO="--tx-in-collateral $collateralUTxO"
 fi
 
 qvfAddress=$(cat $scriptAddressFile)
@@ -57,9 +58,7 @@ $cli $BUILD_TX_CONST_ARGS                                       \
   --spending-plutus-script-v2                                   \
   --spending-reference-tx-in-inline-datum-present               \
   --spending-reference-tx-in-redeemer-file $qvfRedeemerFile     \
-  $txInUTxO                                                     \
-  --tx-in-collateral "$collateralUTxO"                          \
-  $txOutUTxO                                                    \
+  $txInUTxO $txInCollateralUTxO $txOutUTxO                      \
   --tx-out "$govOutput"                                         \
   --tx-out-inline-datum-file $currentDatumFile                  \
   --invalid-hereafter $cappedSlot                               \

--- a/scripts/contribute.sh
+++ b/scripts/contribute.sh
@@ -57,7 +57,9 @@ $cli $BUILD_TX_CONST_ARGS                                       \
   --spending-plutus-script-v2                                   \
   --spending-reference-tx-in-inline-datum-present               \
   --spending-reference-tx-in-redeemer-file $qvfRedeemerFile     \
-  $txInUTxO $txInCollateralUTxO $txOutUTxO                      \
+  $txInUTxO                                                     \
+  --tx-in-collateral "$collateralUTxO"                          \
+  $txOutUTxO                                                    \
   --tx-out "$govOutput"                                         \
   --tx-out-inline-datum-file $currentDatumFile                  \
   --invalid-hereafter $cappedSlot                               \

--- a/scripts/distribute-prize.sh
+++ b/scripts/distribute-prize.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-. $REPO/scripts/initiation.sh
+if [ -z $REPO ]; then
+  echo "The \$REPO environment variable is not defined. Please review the script at"
+  echo "\`scripts/local-env.sh\` and make any desired changes, and then assign the"
+  echo "absolute path to this repository to \$REPO before proceeding."
+  return 1
+else
+  . $REPO/scripts/local-env.sh
+fi
+
+. $REPO/scripts/env.sh
 
 if [ "$ENV" == "dev" ]; then
   projectTokenName=$(project_index_to_token_name "$1")
@@ -8,6 +17,8 @@ else
   projectTokenName=$1
 fi
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 regSym=$(cat $regSymFile)

--- a/scripts/donate-to-project.sh
+++ b/scripts/donate-to-project.sh
@@ -300,7 +300,7 @@ else
     sign_and_submit_tx $custodialWalletsDir/$walletLabel.skey $preDir/$collateralKeyHolder.skey $preDir/$keyHolder.skey
     transactionHash=$($cli transaction txid --tx-file $txSigned)
     echo "$transactionHash"
-    store_current_slot $projectTokenName 
+    store_current_slot_2 $projectTokenName $keyHolder 
     # }}}
   else
     # {{{

--- a/scripts/donate-to-project.sh
+++ b/scripts/donate-to-project.sh
@@ -9,9 +9,11 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 regSym=$(cat $regSymFile)
@@ -89,7 +91,7 @@ dev() {
     txInArg="--tx-in $inUTxO --tx-in-collateral $inUTxO"
     if [ $i -eq $lastTxIndex ]; then
       projectUTxOObj="$(get_projects_state_utxo $projectTokenName)"
-      projectUTxO=$(remove_quotes $(echo $projectUTxOObj | jq -c .utxo))
+      projectUTxO=$(echo $projectUTxOObj | jq -r .utxo)
       projectUpdatedDatum=$(mkProjectDatum $donorCount)
       echo "$projectUpdatedDatum" > $updatedDatumFile
       projectOutput="$qvfAddress + 1500000 lovelace + 1 $projectAsset"

--- a/scripts/eliminate-one-project.sh
+++ b/scripts/eliminate-one-project.sh
@@ -9,8 +9,10 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 regSym=$(cat $regSymFile)

--- a/scripts/emulate-outcome.sh
+++ b/scripts/emulate-outcome.sh
@@ -22,8 +22,8 @@ if [ "$scriptUTxOs" == "$(cat $scriptUTxOsFile)" ]; then
   echo "NoChange"
 else 
   $qvf emulate-outcome "$scriptUTxOs"
+  echo $scriptUTxOs > $scriptUTxOsFile
 fi 
 
 
-echo $scriptUTxOs > $scriptUTxOsFile
 

--- a/scripts/emulate-outcome.sh
+++ b/scripts/emulate-outcome.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ -z $REPO ]; then
   echo
   echo "The \$REPO environment variable is not defined. Please review the script at"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1348,8 +1348,8 @@ fi
 if [ -f $preDir/$collateralKeyHolder.vkey ] && [ -f $preDir/$collateralKeyHolder.skey ] && [ -f $preDir/$collateralKeyHolder.addr ] && [ -f $preDir/$collateralKeyHolder.pkh ]; then
   collateral_utxos=$(get_wallet_lovelace_utxos $collateralKeyHolder)
   collateral_utxoCount=$(echo "$collateral_utxos" | jq length)
-  totalLovelace=$(get_total_lovelaces_from_json "$collateral_utxos")
-  if [ $totalLovelace -ge $minCollateralLovelaces ]; then
+  collateral_totalLovelace=$(get_total_lovelaces_from_json "$collateral_utxos")
+  if [ $collateral_totalLovelace -ge $minCollateralLovelaces ]; then
     if [ $collateral_utxoCount -gt 1 ]; then
       tidy_up_wallet $collateralKeyHolder "Multiple UTxOs found in the collateral key holder's wallet. Tidying up...\n$collateral_utxos"
       echo "Done. The key holder wallet is ready."

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1309,12 +1309,12 @@ donate_to_smart_contract() {
 # inside a single UTxO.
 # {{{
 if [ -f $preDir/$keyHolder.vkey ] && [ -f $preDir/$keyHolder.skey ] && [ -f $preDir/$keyHolder.addr ] && [ -f $preDir/$keyHolder.pkh ]; then
-  utxos=$(get_wallet_lovelace_utxos $keyHolder)
-  utxoCount=$(echo "$utxos" | jq length)
-  totalLovelace=$(get_total_lovelaces_from_json "$utxos")
-  if [ $totalLovelace -ge $minStartingLovelaces ] || [ -f $scriptAddressFile ]; then
-    if [ $utxoCount -gt 1 ]; then
-      tidy_up_wallet $keyHolder "Multiple UTxOs found in the key holder's wallet. Tidying up...\n$utxos"
+  keyHolder_utxos=$(get_wallet_lovelace_utxos $keyHolder)
+  keyHolder_utxoCount=$(echo "$keyHolder_utxos" | jq length)
+  keyHolder_totalLovelace=$(get_total_lovelaces_from_json "$keyHolder_utxos")
+  if [ $keyHolder_totalLovelace -ge $minStartingLovelaces ] || [ -f $scriptAddressFile ]; then
+    if [ $keyHolder_utxoCount -gt 1 ]; then
+      tidy_up_wallet $keyHolder "Multiple UTxOs found in the key holder's wallet. Tidying up...\n$keyHolder_utxos"
       echo "Done. The key holder wallet is ready."
     fi
     export keyHoldersAddress=$(cat "$preDir/$keyHolder.addr")
@@ -1346,12 +1346,12 @@ fi
 # experience for non-technical users.
 # {{{
 if [ -f $preDir/$collateralKeyHolder.vkey ] && [ -f $preDir/$collateralKeyHolder.skey ] && [ -f $preDir/$collateralKeyHolder.addr ] && [ -f $preDir/$collateralKeyHolder.pkh ]; then
-  utxos=$(get_wallet_lovelace_utxos $collateralKeyHolder)
-  utxoCount=$(echo "$utxos" | jq length)
-  totalLovelace=$(get_total_lovelaces_from_json "$utxos")
+  collateral_utxos=$(get_wallet_lovelace_utxos $collateralKeyHolder)
+  collateral_utxoCount=$(echo "$collateral_utxos" | jq length)
+  totalLovelace=$(get_total_lovelaces_from_json "$collateral_utxos")
   if [ $totalLovelace -ge $minCollateralLovelaces ]; then
-    if [ $utxoCount -gt 1 ]; then
-      tidy_up_wallet $collateralKeyHolder "Multiple UTxOs found in the collateral key holder's wallet. Tidying up...\n$utxos"
+    if [ $collateral_utxoCount -gt 1 ]; then
+      tidy_up_wallet $collateralKeyHolder "Multiple UTxOs found in the collateral key holder's wallet. Tidying up...\n$collateral_utxos"
       echo "Done. The key holder wallet is ready."
     fi
     export collateralKeyHoldersAddress=$(cat "$preDir/$collateralKeyHolder.addr")
@@ -1411,23 +1411,23 @@ deplete_reference_wallet() {
 #     Lovelaces stored at the found script address.
 # {{{
 if [ -f $preDir/$referenceWallet.vkey ] && [ -f $preDir/$referenceWallet.skey ] && [ -f $preDir/$referenceWallet.addr ] && [ -f $preDir/$referenceWallet.pkh ]; then
-  utxos=$(get_wallet_lovelace_utxos $referenceWallet)
-  utxoCount=$(echo "$utxos" | jq length)
-  totalLovelace=$(get_total_lovelaces_from_json "$utxos")
-  if [ $utxoCount -eq 3 ]; then
+  ref_wallet_utxos=$(get_wallet_lovelace_utxos $referenceWallet)
+  ref_wallet_utxoCount=$(echo "$ref_wallet_utxos" | jq length)
+  ref_wallet_totalLovelace=$(get_total_lovelaces_from_json "$ref_wallet_utxos")
+  if [ $ref_wallet_utxoCount -eq 3 ]; then
     if [ -f $scriptAddressFile ]; then
-      scriptUTxOs=$(get_all_script_utxos_datums_values $(cat $scriptAddressFile))
-      totalLovelace=$(get_total_lovelaces_from_json "$scriptUTxOs")
-      if [ $totalLovelace -eq 0 ]; then
-        deplete_reference_wallet "The reference wallet is not empty, while the contract is. Depleting the reference wallet into key holder's...\n$utxos"
+      qvf_utxos=$(get_all_script_utxos_datums_values $(cat $scriptAddressFile))
+      qvf_totalLovelace=$(get_total_lovelaces_from_json "$qvf_utxos")
+      if [ $qvf_totalLovelace -eq 0 ]; then
+        deplete_reference_wallet "The reference wallet is not empty, while the contract is. Depleting the reference wallet into key holder's...\n$ref_wallet_utxos"
         tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to an un-initiated script address..."
       fi
     else
-      deplete_reference_wallet "The reference wallet is not empty, while there is no contract address file stored. Depleting the reference wallet...\n$utxos"
+      deplete_reference_wallet "The reference wallet is not empty, while there is no contract address file stored. Depleting the reference wallet...\n$ref_wallet_utxos"
       tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to missing script address file..."
     fi
-  elif [ $totalLovelace -gt 0 ]; then
-    deplete_reference_wallet "The reference wallet has some Lovelaces, but the number of its UTxOs are not exactly 3 (the number of scripts). Depleting the reference wallet...\n$utxos"
+  elif [ $ref_wallet_totalLovelace -gt 0 ]; then
+    deplete_reference_wallet "The reference wallet has some Lovelaces, but the number of its UTxOs are not exactly 3 (the number of scripts). Depleting the reference wallet...\n$ref_wallet_utxos"
     tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to not having exactly 3 UTxOs, but having some Lovelaces..."
   fi
 elif [ -f $preDir/$referenceWallet.vkey ] || [ -f $preDir/$referenceWallet.skey ] || [ -f $preDir/$referenceWallet.addr ] || [ -f $preDir/$referenceWallet.pkh ]; then

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export WHITE="\033[97m"
 export NO_COLOR="\033[0m"
 
@@ -82,44 +84,7 @@ log_into() {
 
 export scriptLabel="qvf"
 export fileNamesJSONFile="$preDir/fileNames.json"
-# Creating the $fileNamesJSONFile:
-# {{{
-touch $fileNamesJSONFile
-if [ ! "$(cat $fileNamesJSONFile)" ]; then
-  echo "{ \"ocfnPreDir\"              : \"$preDir\""                      > $fileNamesJSONFile
-  echo ", \"ocfnProjectsPreDir\"      : \"projects\""                    >> $fileNamesJSONFile
-  echo ", \"ocfnQueryJSON\"           : \"query.json\""                  >> $fileNamesJSONFile
-  echo ", \"ocfnScriptQueryJSON\"     : \"script-query.json\""           >> $fileNamesJSONFile
-  echo ", \"ocfnDeadlineTokenNameHex\": \"deadline-token-name.hex\""     >> $fileNamesJSONFile
-  echo ", \"ocfnGovernanceMinter\"    : \"governance-policy.plutus\""    >> $fileNamesJSONFile
-  echo ", \"ocfnGovernanceSymbol\"    : \"governance-policy.symbol\""    >> $fileNamesJSONFile
-  echo ", \"ocfnQVFGovernanceUTxO\"   : \"gov.utxo\""                    >> $fileNamesJSONFile
-  echo ", \"ocfnRegistrationMinter\"  : \"registration-policy.plutus\""  >> $fileNamesJSONFile
-  echo ", \"ocfnRegistrationSymbol\"  : \"registration-policy.symbol\""  >> $fileNamesJSONFile
-  echo ", \"ocfnRegistrationRefUTxO\" : \"registration-policy.refUTxO\"" >> $fileNamesJSONFile
-  echo ", \"ocfnDonationMinter\"      : \"donation-policy.plutus\""      >> $fileNamesJSONFile
-  echo ", \"ocfnDonationSymbol\"      : \"donation-policy.symbol\""      >> $fileNamesJSONFile
-  echo ", \"ocfnDonationRefUTxO\"     : \"donation-policy.refUTxO\""     >> $fileNamesJSONFile
-  echo ", \"ocfnQVFMainValidator\"    : \"$scriptLabel.plutus\""         >> $fileNamesJSONFile
-  echo ", \"ocfnQVFRefUTxO\"          : \"$scriptLabel.refUTxO\""        >> $fileNamesJSONFile
-  echo ", \"ocfnContractAddress\"     : \"$scriptLabel.addr\""           >> $fileNamesJSONFile
-  echo ", \"ocfnDeadlineSlot\"        : \"deadline.slot\""               >> $fileNamesJSONFile
-  echo ", \"ocfnDeadlineDatum\"       : \"deadline.govDatum\""           >> $fileNamesJSONFile
-  echo ", \"ocfnInitialGovDatum\"     : \"initial.govDatum\""            >> $fileNamesJSONFile
-  echo ", \"ocfnCurrentDatum\"        : \"current.datum\""               >> $fileNamesJSONFile
-  echo ", \"ocfnUpdatedDatum\"        : \"updated.datum\""               >> $fileNamesJSONFile
-  echo ", \"ocfnNewDatum\"            : \"new.datum\""                   >> $fileNamesJSONFile
-  echo ", \"ocfnQVFRedeemer\"         : \"qvf.redeemer\""                >> $fileNamesJSONFile
-  echo ", \"ocfnMinterRedeemer\"      : \"minter.redeemer\""             >> $fileNamesJSONFile
-  echo ", \"ocfnProjectTokenName\"    : \"project-token-name.hex\""      >> $fileNamesJSONFile
-  echo ", \"ocfnScriptUTxOs\"         : \"script.utxos\""                >> $fileNamesJSONFile
-  echo ", \"ocfnRegisteredProjects\"  : \"registered-projects.json\""    >> $fileNamesJSONFile
-  echo "}" >> $fileNamesJSONFile
-else
-  newContent=$(cat $fileNamesJSONFile | jq -c --arg preDir "$preDir" '.ocfnPreDir = $preDir')
-  echo "$newContent" > $fileNamesJSONFile
-fi
-# }}}
+
 getFileName() {
   echo $preDir/$(cat $fileNamesJSONFile | jq -r .$1)
 }
@@ -129,11 +94,8 @@ getFileName() {
 export queryJSONFile=$(getFileName ocfnQueryJSON)
 export projsPreDir=$(getFileName ocfnProjectsPreDir)
 export tempBashFile="$preDir/temp.sh"
-touch $tempBashFile
 export tidyUpLogFile="$preDir/tidyup.log"
-touch $tidyUpLogFile
 export refDepletionLogFile="$preDir/ref-depletion.log"
-touch $refDepletionLogFile
 
 # Main script:
 export mainScriptFile=$(getFileName ocfnQVFMainValidator)
@@ -155,12 +117,7 @@ export qvfRedeemerFile=$(getFileName ocfnQVFRedeemer)
 export minterRedeemerFile=$(getFileName ocfnMinterRedeemer)
  
 export projectTokenNameFile=$(getFileName ocfnProjectTokenName)
-touch $projectTokenNameFile
 export registeredProjectsFile=$(getFileName ocfnRegisteredProjects)
-touch $registeredProjectsFile
-if [ ! "$(cat $registeredProjectsFile)" ]; then
-  echo "[]" > $registeredProjectsFile
-fi
 export govUTxOFile=$(getFileName ocfnQVFGovernanceUTxO)
 export qvfRefUTxOFile=$(getFileName ocfnQVFRefUTxO)
 export regRefUTxOFile=$(getFileName ocfnRegistrationRefUTxO)
@@ -176,17 +133,8 @@ minCollateralAda=5
 
 export deadlineSlotFile=$(getFileName ocfnDeadlineSlot)
 export latestInteractionSlotFile="$preDir/latestInteraction.slot"
-touch $latestInteractionSlotFile
-if [ ! "$(cat $latestInteractionSlotFile)" ]; then
-  echo "{\"$keyHolder\":0"        > $latestInteractionSlotFile
-  echo ",\"$referenceWallet\":0" >> $latestInteractionSlotFile
-  echo ",\"$scriptLabel\":0"     >> $latestInteractionSlotFile
-  echo ",\"deadline\":0"         >> $latestInteractionSlotFile
-  echo "}"                       >> $latestInteractionSlotFile
-fi
 
 export scriptUTxOsFile=$(getFileName ocfnScriptUTxOs)
-touch $scriptUTxOsFile
 
 # bounty escrow wallet address
 export bountyEscrowWalletAddress="addr_test1qp72z5fzxc5yl8ht3wqme46reu04stq4mufm0660l7hkawl4w0e4s0x47jsnwf2g2dn7k4lq84skgrlyvz6rtvgh9l5qjmy54m"
@@ -198,7 +146,6 @@ generate_protocol_params() {
   # }}}
 }
 export protocolsFile="$preDir/protocol.json"
-generate_protocol_params
 export dummyTx="$preDir/tx.dummy"
 export txBody="$preDir/tx.unsigned"
 export txSigned="$preDir/tx.signed"
@@ -218,12 +165,7 @@ export deadlineLovelaces=1500000
 
 
 # REQUIRED FOR DEVELOPMENT:
-###### tempRedeemer="$preDir/temp.redeemer"
-###### touch $tempRedeemer
-###### echo "{\"constructor\":11,\"fields\":[]}" > $tempRedeemer
-devRedeemer="$preDir/dev.redeemer"
-touch $devRedeemer
-echo "{\"constructor\":20,\"fields\":[]}" > $devRedeemer
+export devRedeemer="$preDir/dev.redeemer"
 # =========================
 
 
@@ -940,9 +882,11 @@ get_total_lovelaces_from_json() {
 # Takes 1 argument:
 #   1. Script data JSON.
 hash_datum() {
+  # {{{
   proxyFile=$preDir/tmp.json
   echo "$1" > $proxyFile
   $cli transaction hash-script-data --script-data-file $proxyFile
+  # }}}
 }
 
 
@@ -988,11 +932,10 @@ jq_to_bash_3() {
 # Looks through the given response from calling the `qvf-cli` application, and
 # if it'll `return 1` if it finds a "FAILED:" or "FAILED." or "FAILED".
 #
-# Takes 1 argument:
-#   1. Response from calling `qvf-cli`.
+# Takes the output from `qvf-cli` as its argument(s).
 check_qvf_cli_result() {
   # {{{
-  for log in $1; do
+  for log in $@; do
     if [ "$log" == "FAILED:" ] || [ "$log" == "FAILED." ] || [ "$log" == "FAILED" ]; then
       if [ "$ENV" == "dev" ]; then
         echo $qvfRes
@@ -1017,14 +960,18 @@ get_all_projects_utxos_datums_values() {
 
 # Takes no arguments.
 get_all_projects_info_utxos_datums_values() {
+  # {{{
   constr=$($qvf get-constr-index ProjectInfo)
   get_all_projects_utxos_datums_values | jq -c --arg constr "$constr" 'map(select((.datum .constructor) == ($constr | tonumber)))'
+  # }}}
 }
 
 # Takes no arguments.
 get_all_projects_state_utxos_datums_values() {
+  # {{{
   constr=$($qvf get-constr-index ProjectInfo)
   get_all_projects_utxos_datums_values | jq -c --arg constr "$constr" 'map(select((.datum .constructor) != ($constr | tonumber)))'
+  # }}}
 }
 
 # Takes no arguments.
@@ -1135,250 +1082,6 @@ get_projects_owner_address() {
 #########################################################################
 
 
-# Given a wallet, a script, and other arguments, this function constructs,
-# signs and submits a transaction for interacting with a smart contract.
-#
-# Takes 7 arguments:
-#   1. User's wallet address file,
-#   2. User's wallet signing key file,
-#   3. The script file,
-#   4. Script's current datum JSON file,
-#   5. Redeemer's JSON file for the intended endpoint,
-#   6. Amount that should be added to script's holding,
-#   7. Updated datum of the script after the transaction.
-interact_with_smart_contract() {
-  # {{{
-
-    # Build script address from a script, if script address does not exist. 
-    # The address name is the same as the script, except its extension is changed to .addr
-    # script_addr=$($3 | sed "s/\..*/.addr/") # Name is $3 with its ext changed to .addr
-    # Safety check to not overwrite any existing file, and to avoid rebuilding if already built.
-    if [ -f $script_addr ]
-    then
-    echo "Using the script address $script_addr, which already exists. If this is incorrect, then move, rename, or change $script_addr and run again."
-    else
-    plutus_script_to_address # $3 $script_addr # Builds script file address
-    fi
-    script_addr=$scriptAddressFile
-
-    users_utxo=$(get_first_utxo_of $1)
-    script_holding=$(get_first_lovelace_count_of $script_addr)
-    extra_output=$(expr $6 + $script_holding)
-
-    $cli transaction build                        \
-        --tx-in $users_utxo                       \
-        --tx-in $(get_first_utxo_of $script_addr) \
-        --tx-in-script-file $3                    \
-        --tx-in-datum-file $4                     \
-        --tx-in-redeemer-file $5                  \
-        --tx-in-collateral $users_utxo            \
-        --tx-out $(cat $1)+$extra_output          \
-        --tx-out-datum-embed-file  $7             \
-        --change-address $(cat $1)                \
-        --protocol-params-file protocol.json      \
-        --out-file tx.raw                         \
-        $MAGIC
-
-    $cli transaction sign                         \
-        --tx-body-file tx.raw                     \
-        --signing-key-file $2                     \
-        $MAGIC                                    \
-        --out-file tx.signed
-
-    $cli transaction submit                       \
-        $MAGIC                                    \
-        --tx-file tx.signed
-  # }}}
-}
-
-# Runs qvf-cli cmds with nix-shell from outside nix-shell
-# Uses a HERE doc to do this
-# PARAMS: $1=donor_pkh_file $2=receiver_pkh_file $3=lovelace_amt $4=current_datum
-update_datum_donate_qvf_cli() {
-  # {{{
-    # Edit these: ---------
-    path_to_plutus_apps=$HOME/plutus-apps
-    path_to_quadratic_voting=$HOME/quadraticvoting
-    current_path=$(pwd)
-    # ---------------------
-
-    donor_pkh_file=$1
-    receiver_pkh_file=$2
-    lovelace_amt=$3
-
-    # Make the script to execute within the nix-shell with a HERE DOC
-    cat > "$path_to_plutus_apps"/update-datum.sh <<EOF
-#! /usr/bin/env nix-shell
-#! nix-shell -i sh
-
-cd $path_to_quadratic_voting
-. scripts/test_remote.sh
-donorsPKH=$(cat $current_path/$1)
-obj=\$(find_utxo_with_project \$scriptAddr "\$policyId\$tokenName" \$(cat $2))
-len=\$(echo \$obj | jq length)
-if [ \$len -eq 0 ]; then
-    echo "FAILED to find the project."
-else
-    currDatum="$current_path/curr.datum"
-    updatedDatum="$current_path/updated.datum"
-    action="$current_path/donate.redeemer"
-    obj=\$(echo \$obj | jq .[0])
-    utxo=\$(echo \$obj | jq .utxo)
-    datumHash=\$(echo \$obj | jq .datumHash)
-    datumValue=\$(echo \$obj | jq .datumValue)
-    lovelace=\$(echo \$obj | jq .lovelace | jq tonumber)
-    newLovelace=\$(expr \$lovelace + $3)
-    echo \$lovelace
-    echo \$newLovelace > newLovelace
-    echo \$datumValue > \$currDatum
-    $qvf donate $(cat $donor_pkh_file) $(cat $receiver_pkh_file) \$lovelace_amt \$current_datum out_datum.json out_redeem.json
-    $qvf pretty-datum \$(cat \$updatedDatum)
-    cp out_datum.json "$current_path" # Optional, see how workflow works out
-    cp out_redeem.json "$current_path" # Optional, see how workflow works out
-    cp newLovelace "$current_path" # Optional, see how workflow works out
-    echo "DONE."
-fi
-exit # Exit nix-shell
-EOF
-    # Run the HERE file commands in nix-shell
-    cd "$path_to_plutus_apps"
-    chmod +x update-datum.sh
-    ./update-datum.sh
-    cd "$current_path"
-  # }}}
-}
-
-# WIP
-# cardano-cli transaction cmd to donate
-# PARAMS: $1=donorAddrFile $2=donorSKeyFile $3=utxoFromDonor $4=utxoAtScript $5=currentDatum $6lovelace_amt_script $7=lovelace_amt_donation
-donate_to_smart_contract() {
-  # {{{
-    # Edit these: ---------
-    authAsset=62a65c6ce2c30f7040f0bc8cc5eb5f3f07521757125a03d743124a54.517561647261546f6b656e
-    scriptAddr=addr_test1wpl9c67dav6n9gjxlyafg6dmsql8tafy3pwd3fy06tu26nqzphnsx
-    scriptFile="qvf.plutus"      # The Plutus script file (qvf.plutus)
-    donorAddrFile="$1"   # The file that contains donor's wallet address.
-    donorSKeyFile="$2"   # The file that contains donor's signing key.
-    #utxoFromDonor="efd9d27b0ba008b8495aee6d4d01c5ebe0c281b55a623a31fe0b631c6365cb22"   # A UTxO from donor's wallet that has enough ADA for donation, tx fee and collateral.
-    utxoFromDonor="$3"   # A UTxO from donor's wallet that has enough ADA for donation, tx fee and collateral.
-    utxoAtScript="$4"    # The UTxO at the script with the current datum attached.
-    currentDatum="$5"    # JSON file containing current state of the contract, about to be updated.
-    newDatum="out_datum.json"        # JSON file containing updated state of the contract.
-    redeemer="out_redeem.json"        # JSON file containing the `Donate` redeemer.
-    lovelace_amt_script="$6"
-    lovelace_amt_donation="$7"
-    newLovelaceCount=$(expr lovelace_amt_script + lovelace_amt_donation) # Current Lovelace count of $utxoAtScript, plus the donated amount.
-    # ---------------------
-
-    # Construct the transaction:
-    $cli transaction build --babbage-era $MAGIC                            \
-        --tx-in $utxoFromDonor                                             \
-        --tx-in-collateral $utxoFromDonor                                  \
-        --tx-in $utxoAtScript                                              \
-        --tx-in-datum-file $currentDatum                                   \
-        --tx-in-script-file $scriptFile                                    \
-        --tx-in-redeemer-file $redeemer                                    \
-        --tx-out "$scriptAddr + $newLovelaceCount lovelace + 1 $authAsset" \
-        --tx-out-datum-embed-file $newDatum                                \
-        --change-address $(cat $donorAddrFile)                             \
-        --protocol-params-file protocol.json                               \
-        --out-file tx.unsigned
-
-    # Sign the transaction:
-    $cli transaction sign $MAGIC          \
-        --tx-body-file tx.unsigned        \
-        --signing-key-file $donorSKeyFile \
-        --out-file tx.signed
-
-    # Submit the transaction:
-    $cli transaction submit $MAGIC --tx-file tx.signed
-  # }}}
-}
-
-
-# Checks if the $keyHolder wallet exists (properly), and that it has a single
-# UTxO with enough Ada inside.
-#
-# If the wallet files exist partially, this function terminates the script
-# without any changes. If there are no wallet files, the $keyHolder wallet is
-# generated, but the script is terminated, prompting the user to send some Ada
-# to the wallet.
-#
-# If the wallet is present, it's made sure the total Lovelace count is more
-# than the minimum, and if they are spread out between multiple UTxOs, it'll
-# invoke the `tidy_up_wallet` function so that all the money is collected
-# inside a single UTxO.
-# {{{
-if [ -f $preDir/$keyHolder.vkey ] && [ -f $preDir/$keyHolder.skey ] && [ -f $preDir/$keyHolder.addr ] && [ -f $preDir/$keyHolder.pkh ]; then
-  keyHolder_utxos=$(get_wallet_lovelace_utxos $keyHolder)
-  keyHolder_utxoCount=$(echo "$keyHolder_utxos" | jq length)
-  keyHolder_totalLovelace=$(get_total_lovelaces_from_json "$keyHolder_utxos")
-  if [ $keyHolder_totalLovelace -ge $minStartingLovelaces ] || [ -f $scriptAddressFile ]; then
-    if [ $keyHolder_utxoCount -gt 1 ]; then
-      tidy_up_wallet $keyHolder "Multiple UTxOs found in the key holder's wallet. Tidying up...\n$keyHolder_utxos"
-      echo "Done. The key holder wallet is ready."
-    fi
-    export keyHoldersAddress=$(cat "$preDir/$keyHolder.addr")
-    export keyHoldersPubKeyHash=$(cat "$preDir/$keyHolder.pkh")
-    export keyHoldersSigningKeyFile="$preDir/$keyHolder.skey"
-  else
-    echo "The key holder wallet doesn't have enough Ada. Please make sure a"
-    echo -e "minimum of $WHITE$minStartingAda Ada$NO_COLOR is available:"
-    echo ""
-    echo -e "$WHITE$(cat $preDir/$keyHolder.addr)$NO_COLOR"
-    return 1
-  fi
-elif [ -f $preDir/$keyHolder.vkey ] || [ -f $preDir/$keyHolder.skey ] || [ -f $preDir/$keyHolder.addr ] || [ -f $preDir/$keyHolder.pkh ]; then
-  echo "Some key holder wallet files are missing."
-  return 1
-else
-  generate_wallet $keyHolder
-  echo "No key holder wallet was found. The wallet is generated for you."
-  echo -e "Please deposit a minimum of $WHITE$minStartingAda Ada$NO_COLOR before proceeding:"
-  echo ""
-  echo -e "$WHITE$(cat $preDir/$keyHolder.addr)$NO_COLOR"
-  return 1
-fi
-# }}}
-
-
-# A similar check for $collateralKeyHolder. This wallet is meant for providing
-# the collateral for user-facing endpoints to provide a more "approachable"
-# experience for non-technical users.
-# {{{
-if [ -f $preDir/$collateralKeyHolder.vkey ] && [ -f $preDir/$collateralKeyHolder.skey ] && [ -f $preDir/$collateralKeyHolder.addr ] && [ -f $preDir/$collateralKeyHolder.pkh ]; then
-  collateral_utxos=$(get_wallet_lovelace_utxos $collateralKeyHolder)
-  collateral_utxoCount=$(echo "$collateral_utxos" | jq length)
-  collateral_totalLovelace=$(get_total_lovelaces_from_json "$collateral_utxos")
-  if [ $collateral_totalLovelace -ge $minCollateralLovelaces ]; then
-    if [ $collateral_utxoCount -gt 1 ]; then
-      tidy_up_wallet $collateralKeyHolder "Multiple UTxOs found in the collateral key holder's wallet. Tidying up...\n$collateral_utxos"
-      echo "Done. The key holder wallet is ready."
-    fi
-    export collateralKeyHoldersAddress=$(cat "$preDir/$collateralKeyHolder.addr")
-    export collateralKeyHoldersPubKeyHash=$(cat "$preDir/$collateralKeyHolder.pkh")
-    export collateralKeyHoldersSigningKeyFile="$preDir/$collateralKeyHolder.skey"
-  else
-    echo "The collateral key holder wallet doesn't have enough Ada. Please make sure a"
-    echo -e "minimum of $WHITE$minCollateralAda Ada$NO_COLOR is available:"
-    echo ""
-    echo -e "$WHITE$(cat $preDir/$collateralKeyHolder.addr)$NO_COLOR"
-    return 1
-  fi
-elif [ -f $preDir/$collateralKeyHolder.vkey ] || [ -f $preDir/$collateralKeyHolder.skey ] || [ -f $preDir/$collateralKeyHolder.addr ] || [ -f $preDir/$collateralKeyHolder.pkh ]; then
-  echo "Some key holder wallet files are missing."
-  return 1
-else
-  generate_wallet $collateralKeyHolder
-  echo "No collateral key holder wallet was found. The wallet is generated for you."
-  echo -e "Please deposit a minimum of $WHITE$minCollateralAda Ada$NO_COLOR before proceeding:"
-  echo ""
-  echo -e "$WHITE$(cat $preDir/$collateralKeyHolder.addr)$NO_COLOR"
-  return 1
-fi
-# }}}
-
-
 # Consumes all the UTxOs sitting at the $referenceWallet, and sends them to the
 # $keyHolder wallet.
 #
@@ -1393,50 +1096,10 @@ deplete_reference_wallet() {
   generate_protocol_params
   $cli $BUILD_TX_CONST_ARGS                    \
     $(get_all_input_utxos_at $referenceWallet) \
-    --change-address $keyHoldersAddress
+    --change-address $(cat "$preDir/$keyHolder.addr")
   sign_and_submit_tx $preDir/$referenceWallet.skey
   store_current_slot $referenceWallet
   wait_for_new_slot $referenceWallet
   show_utxo_tables $referenceWallet
   # }}}
 }
-
-
-# A similar check for the $referencWallet. There are 3 circumstances that lead
-# to an automated depletion of the $referenceWallet into $keyHolder:
-#   - There are some Lovelaces in the wallet, but the UTxO count is not exactly
-#     the same as the $scriptCount,
-#   - There are exactly $scriptCount UTxOs in the wallet, but there is no
-#     $scriptAddressFile,
-#   - There are exactly $scriptCount UTxOs in the wallet, but there are no
-#     Lovelaces stored at the found script address.
-# {{{
-if [ -f $preDir/$referenceWallet.vkey ] && [ -f $preDir/$referenceWallet.skey ] && [ -f $preDir/$referenceWallet.addr ] && [ -f $preDir/$referenceWallet.pkh ]; then
-  ref_wallet_utxos=$(get_wallet_lovelace_utxos $referenceWallet)
-  ref_wallet_utxoCount=$(echo "$ref_wallet_utxos" | jq length)
-  ref_wallet_totalLovelace=$(get_total_lovelaces_from_json "$ref_wallet_utxos")
-  if [ $ref_wallet_utxoCount -eq 3 ]; then
-    if [ -f $scriptAddressFile ]; then
-      qvf_utxos=$(get_all_script_utxos_datums_values $(cat $scriptAddressFile))
-      qvf_totalLovelace=$(get_total_lovelaces_from_json "$qvf_utxos")
-      if [ $qvf_totalLovelace -eq 0 ]; then
-        deplete_reference_wallet "The reference wallet is not empty, while the contract is. Depleting the reference wallet into key holder's...\n$ref_wallet_utxos"
-        tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to an un-initiated script address..."
-      fi
-    else
-      deplete_reference_wallet "The reference wallet is not empty, while there is no contract address file stored. Depleting the reference wallet...\n$ref_wallet_utxos"
-      tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to missing script address file..."
-    fi
-  elif [ $ref_wallet_totalLovelace -gt 0 ]; then
-    deplete_reference_wallet "The reference wallet has some Lovelaces, but the number of its UTxOs are not exactly 3 (the number of scripts). Depleting the reference wallet...\n$ref_wallet_utxos"
-    tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to not having exactly 3 UTxOs, but having some Lovelaces..."
-  fi
-elif [ -f $preDir/$referenceWallet.vkey ] || [ -f $preDir/$referenceWallet.skey ] || [ -f $preDir/$referenceWallet.addr ] || [ -f $preDir/$referenceWallet.pkh ]; then
-  echo "Some reference wallet files are missing."
-  return 1
-else
-  generate_wallet $referenceWallet
-fi
-# }}}
-
-export referenceWalletAddress=$(cat "$preDir/$referenceWallet.addr")

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -127,7 +127,6 @@ getFileName() {
 # Exporting variables for required file names:
 # {{{
 export queryJSONFile=$(getFileName ocfnQueryJSON)
-export scriptQueryJSONFile=$(getFileName ocfnScriptQueryJSON)
 export projsPreDir=$(getFileName ocfnProjectsPreDir)
 export tempBashFile="$preDir/temp.sh"
 touch $tempBashFile
@@ -790,8 +789,8 @@ get_wallet_lovelace_utxos() {
 #   1. Script address.
 get_all_script_utxos_datums_values() {
   # {{{
-  $cli query utxo $MAGIC --address $1 --out-file $scriptQueryJSONFile
-  utxos=$(cat $scriptQueryJSONFile | jq -c 'to_entries
+  $cli query utxo $MAGIC --address $1 --out-file $queryJSONFile
+  temp_utxos=$(cat $queryJSONFile | jq -c 'to_entries
     | map(select((.value | .value | to_entries | length) == 2))
     | map
         ( ( .value
@@ -822,7 +821,7 @@ get_all_script_utxos_datums_values() {
   count=0
   for d in $datums; do
     datumCBOR=$($qvf data-to-cbor "$d")
-    utxos="$(echo "$utxos"            \
+    temp_utxos="$(echo "$utxos"       \
       | jq -c --arg cbor "$datumCBOR" \
               --argjson i "$count"    \
       '.[$i] |= (. += {"datumCBOR": ($cbor | tostring)})'
@@ -840,7 +839,7 @@ get_all_script_utxos_datums_values() {
 #   3. The array of printed UTxOs returned by `qvf-cli`.
 qvf_output_to_tx_ins() {
   # {{{
-  utxos="$(echo "$3" | jq -c 'map(.utxo) | .[]')"
+  temp_utxos="$(echo "$3" | jq -c 'map(.utxo) | .[]')"
   fnl=""
   for u in $utxos; do
     fnl="$fnl $1 $(remove_quotes $u) "$2""

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -768,6 +768,7 @@ get_first_lovelace_count_of() {
 get_wallet_lovelace_utxos() {
   # {{{
   $cli query utxo $MAGIC --address $(cat $preDir/$1.addr) --out-file $queryJSONFile
+  sleep 1
   json=$(cat $queryJSONFile)
   rm -f $queryJSONFile
   echo "$json" | jq -c \

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -817,18 +817,18 @@ get_all_script_utxos_datums_values() {
               )
           }
         )')
-  datums="$(echo "$utxos" | jq -c 'map(.datum) | .[]')"
+  datums="$(echo "$temp_utxos" | jq -c 'map(.datum) | .[]')"
   count=0
   for d in $datums; do
     datumCBOR=$($qvf data-to-cbor "$d")
-    temp_utxos="$(echo "$utxos"       \
+    temp_utxos="$(echo "$temp_utxos"  \
       | jq -c --arg cbor "$datumCBOR" \
               --argjson i "$count"    \
       '.[$i] |= (. += {"datumCBOR": ($cbor | tostring)})'
     )"
     count=$(expr $count + 1)
   done
-  echo $utxos
+  echo $temp_utxos
   # }}}
 }
 
@@ -841,7 +841,7 @@ qvf_output_to_tx_ins() {
   # {{{
   temp_utxos="$(echo "$3" | jq -c 'map(.utxo) | .[]')"
   fnl=""
-  for u in $utxos; do
+  for u in $temp_utxos; do
     fnl="$fnl $1 $(remove_quotes $u) "$2""
   done
   echo "$fnl"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -768,8 +768,9 @@ get_first_lovelace_count_of() {
 #   1. Wallet label.
 get_wallet_lovelace_utxos() {
   # {{{
-  $cli query utxo $MAGIC --address $(cat $preDir/$1.addr) --out-file $queryJSONFile
-  jq -c \
+  touch $preDir/temp.query
+  $cli query utxo $MAGIC --address $(cat $preDir/$1.addr) --out-file $preDir/temp.query
+  cat $preDir/temp.query | jq -c \
     'to_entries
     | map
         ( ( .value
@@ -780,7 +781,7 @@ get_wallet_lovelace_utxos() {
         | { utxo: .key
           , lovelace: (.value | .value | .lovelace)
           }
-        )' $queryJSONFile
+        )'
   # }}}
 }
 

--- a/scripts/fold-accumulate-eliminate-distribute.sh
+++ b/scripts/fold-accumulate-eliminate-distribute.sh
@@ -14,7 +14,7 @@ if [ "$ENV" == "dev" ]; then
   return 1
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 # Takes no arguments.
 get_all_token_names() {

--- a/scripts/fold-donations.sh
+++ b/scripts/fold-donations.sh
@@ -9,13 +9,15 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 MAX_SPENDABLE_UTXOS=8
 
 projectTokenName=$1
 startingPhase=$2
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 regSym=$(cat $regSymFile)
 donSym=$(cat $donSymFile)
@@ -105,7 +107,7 @@ iteration_helper() {
   initialDonationsArg="$(echo "$donations" | jq -c 'map((.lovelace|tostring) + " " + (.assetCount|tostring) + " " + (.datum | tostring)) | reduce .[] as $l (""; if . == "" then $l else . + " " + $l end)')"
   donationsArg="$(jq_to_bash_3 "$initialDonationsArg" "$elemCount")"
   resultJSON="$($qvf "$3" $donationsArg "$(cat $fileNamesJSONFile)")"
-  check_qvf_cli_result "$resultJSON"
+  check_qvf_cli_result $resultJSON
   echo $resultJSON
   lovelaceCount=$(echo "$resultJSON" | jq '(.lovelace|tonumber)')
   mintCount=$(echo "$resultJSON" | jq '(.mint|tonumber)')
@@ -152,7 +154,7 @@ while [ $phase -lt 4 ]; do
           "$projectsStateUTxOObj"                 \
           "$(cat $fileNamesJSONFile)"
         )
-        check_qvf_cli_result "$qvfRes"
+        check_qvf_cli_result $qvfRes
         if [ "$ENV" == "dev" ]; then
           echo $qvfRes
         fi

--- a/scripts/fold-donations.sh
+++ b/scripts/fold-donations.sh
@@ -160,13 +160,14 @@ while [ $phase -lt 4 ]; do
           --mint \"-2 $projectAsset\"
           --mint-tx-in-reference $(cat $regRefUTxOFile)
           --mint-plutus-script-v2
-          --mint-reference-tx-in-redeemer-file $minterRedeemerFile
+          --mint-reference-tx-in-redeemer-file $devRedeemer
           --policy-id $regSym
         "
         collateralUTxO=$(get_first_utxo_of $collateralKeyHolder)
         govAsset=$(cat $govSymFile)
         generate_protocol_params
         buildTx="$cli $BUILD_TX_CONST_ARGS
+          --required-signer-hash $keyHoldersPubKeyHash
           --tx-in $govUTxO           $txInConstant
           --tx-in $projectsInfoUTxO  $txInConstant
           --tx-in $projectsStateUTxO $txInConstant
@@ -178,7 +179,7 @@ while [ $phase -lt 4 ]; do
         "
         echo $buildTx > $tempBashFile
         . $tempBashFile
-        sign_and_submit_tx $preDir/$collateralKeyHolder.skey
+        sign_and_submit_tx $preDir/$keyHolder.skey $preDir/$collateralKeyHolder.skey
         store_current_slot_2 $scriptLabel $collateralKeyHolder
         wait_for_new_slot $scriptLabel
         store_current_slot_2 $scriptLabel $collateralKeyHolder

--- a/scripts/get-bounty-credit-amount.sh
+++ b/scripts/get-bounty-credit-amount.sh
@@ -9,7 +9,7 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 projectWalletAddress=$1
 

--- a/scripts/get-current-funding-round.sh
+++ b/scripts/get-current-funding-round.sh
@@ -11,5 +11,6 @@ fi
 
 . $REPO/scripts/initiation.sh
 
+currentFundingRound=$(jq '.currentFundingRound' $fundingRoundFile)
 
 echo "$currentFundingRound"

--- a/scripts/get-current-funding-round.sh
+++ b/scripts/get-current-funding-round.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z $REPO ]; then
+  echo "The \$REPO environment variable is not defined. Please review the script at"
+  echo "\`scripts/local-env.sh\` and make any desired changes, and then assign the"
+  echo "absolute path to this repository to \$REPO before proceeding."
+  return 1
+else
+  . $REPO/scripts/local-env.sh
+fi
+
+. $REPO/scripts/initiation.sh
+
+
+echo "$currentFundingRound"

--- a/scripts/get-custodial-wallet.sh
+++ b/scripts/get-custodial-wallet.sh
@@ -15,6 +15,6 @@ walletLabel=$1
 if [ -f $custodialWalletsDir/$walletLabel.addr ]; then
   cat $custodialWalletsDir/$walletLabel.addr
 else 
-  generate_wallet $custodialsWalletLabel/$walletLabel
+  generate_wallet $custodialWalletsLabel/$walletLabel
   cat $custodialWalletsDir/$walletLabel.addr
 fi

--- a/scripts/get-custodial-wallet.sh
+++ b/scripts/get-custodial-wallet.sh
@@ -15,6 +15,6 @@ walletLabel=$1
 if [ -f $custodialWalletsDir/$walletLabel.addr ]; then
   cat $custodialWalletsDir/$walletLabel.addr
 else 
-  generate_wallet $custodialWalletsLabel/$walletLabel
+  generate_wallet $custodialWalletsDir/$walletLabel
   cat $custodialWalletsDir/$walletLabel.addr
 fi

--- a/scripts/get-custodial-wallet.sh
+++ b/scripts/get-custodial-wallet.sh
@@ -15,6 +15,6 @@ walletLabel=$1
 if [ -f $custodialWalletsDir/$walletLabel.addr ]; then
   cat $custodialWalletsDir/$walletLabel.addr
 else 
-  generate_wallet $custodialWalletLabel/$walletLabel
+  generate_wallet $custodialsWalletLabel/$walletLabel
   cat $custodialWalletsDir/$walletLabel.addr
 fi

--- a/scripts/get-custodial-wallet.sh
+++ b/scripts/get-custodial-wallet.sh
@@ -5,13 +5,13 @@ if [ -z $REPO ]; then
   echo "absolute path to this repository to \$REPO before proceeding."
   return 1
 else
-. $REPO/scripts/local-env.sh
+  . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 walletLabel=$1
-# check if wallet exists, or if not create it.
+# Check if wallet exists, or if not create it.
 if [ -f $custodialWalletsDir/$walletLabel.addr ]; then
   cat $custodialWalletsDir/$walletLabel.addr
 else 

--- a/scripts/get-custodial-wallet.sh
+++ b/scripts/get-custodial-wallet.sh
@@ -15,6 +15,6 @@ walletLabel=$1
 if [ -f $custodialWalletsDir/$walletLabel.addr ]; then
   cat $custodialWalletsDir/$walletLabel.addr
 else 
-  generate_wallet $custodialWalletsDir/$walletLabel
+  generate_wallet $custodialWalletLabel/$walletLabel
   cat $custodialWalletsDir/$walletLabel.addr
 fi

--- a/scripts/get-match-pool-amount.sh
+++ b/scripts/get-match-pool-amount.sh
@@ -10,6 +10,6 @@ fi
 . $REPO/scripts/env.sh
 
 govUTxOObj="$(get_governance_utxo)"
-govLovelaces=$(remove_quotes $(echo $govUTxOObj | jq -c .lovelace))
+govLovelaces=$(echo $govUTxOObj | jq -r .lovelace)
 
 echo "$govLovelaces"

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -211,6 +211,11 @@ initiate_fund() {
   # }}}
 
   # }}}
+
+    # Update Funding Round
+  if [ $ENV = "prod" ]; then 
+    jq '.currentFundingRound |= .+1' $fundingRoundFile > temp.json && mv temp.json $fundingRoundFile
+  fi
 }
 
 

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -9,7 +9,7 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/env.sh
+. $REPO/scripts/setup.sh
 
 
 startingWallet=1
@@ -133,6 +133,7 @@ initiate_fund() {
   done
   rm -f $registeredProjectsFile
   touch $registeredProjectsFile
+  echo "[]" > $registeredProjectsFile
   rm -rf $projsPreDir
   mkdir -p $projsPreDir
   echo "Getting the current slot..."
@@ -148,7 +149,6 @@ initiate_fund() {
   echo -e "The UTxO is:$WHITE"
   echo "$genesisUTxO"
   echo -e "$NO_COLOR"
-
   # Generating the validation script, minting script, and some other files:
   echo "Finding the scripts and writing them to disk..."
   $qvf generate scripts                   \
@@ -168,9 +168,9 @@ initiate_fund() {
 
   deadlineDatum=$(getFileName ocfnDeadlineDatum)
   govDatumFile=$(getFileName ocfnInitialGovDatum)
-  # NOTE: The order of these 2 assignments matters.
+
   govAsset=$(get_gov_asset)
-  # -----------------------------------------------
+
   regSym=$($cli transaction policyid --script-file $regScriptFile)
   echo $regSym > $regSymFile
   donSym=$($cli transaction policyid --script-file $donScriptFile)
@@ -210,12 +210,12 @@ initiate_fund() {
   deploy_scripts
   # }}}
 
-  # }}}
-
-    # Update Funding Round
+  # Update Funding Round
   if [ $ENV = "prod" ]; then 
     jq '.currentFundingRound |= .+1' $fundingRoundFile > temp.json && mv temp.json $fundingRoundFile
   fi
+
+  # }}}
 }
 
 

--- a/scripts/local-env.sh
+++ b/scripts/local-env.sh
@@ -13,7 +13,7 @@ export cli="cardano-cli"
 export qvf="qvf-cli"
 
 # Absolute path to the directory for storing wallets/artifacts:
-export preDir="$REPO/testnet2"
+export preDir="$REPO/testnet3"
 mkdir -p $preDir
 
 # Change this to "dev" for testing/development:

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -205,7 +205,7 @@ else
         --arg on "$(cat $projectTokenNameFile)"       \
         '{projectTokenName: $on }' )
       echo "$JSON_STRING"
-      store_current_slot_2 $projectTokenName $scriptLabel
+      store_current_slot_3 $projectTokenName $scriptLabel $keyHolder
       # }}}
     else
       # {{{

--- a/scripts/register-project.sh
+++ b/scripts/register-project.sh
@@ -9,9 +9,11 @@ else
   . $REPO/scripts/local-env.sh
 fi
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 regSym=$(cat $regSymFile)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+if [ -z $REPO ]; then
+  echo "The \$REPO environment variable is not defined. Please review the script at"
+  echo "\`scripts/local-env.sh\` and make any desired changes, and then assign the"
+  echo "absolute path to this repository to \$REPO before proceeding."
+  return 1
+else
+  . $REPO/scripts/local-env.sh
+fi
+
+. $REPO/scripts/env.sh
+
+# Creating the $fileNamesJSONFile:
+# {{{
+touch $fileNamesJSONFile
+if [ ! "$(cat $fileNamesJSONFile)" ]; then
+  echo "{ \"ocfnPreDir\"              : \"$preDir\""                      > $fileNamesJSONFile
+  echo ", \"ocfnProjectsPreDir\"      : \"projects\""                    >> $fileNamesJSONFile
+  echo ", \"ocfnQueryJSON\"           : \"query.json\""                  >> $fileNamesJSONFile
+  echo ", \"ocfnScriptQueryJSON\"     : \"script-query.json\""           >> $fileNamesJSONFile
+  echo ", \"ocfnDeadlineTokenNameHex\": \"deadline-token-name.hex\""     >> $fileNamesJSONFile
+  echo ", \"ocfnGovernanceMinter\"    : \"governance-policy.plutus\""    >> $fileNamesJSONFile
+  echo ", \"ocfnGovernanceSymbol\"    : \"governance-policy.symbol\""    >> $fileNamesJSONFile
+  echo ", \"ocfnQVFGovernanceUTxO\"   : \"gov.utxo\""                    >> $fileNamesJSONFile
+  echo ", \"ocfnRegistrationMinter\"  : \"registration-policy.plutus\""  >> $fileNamesJSONFile
+  echo ", \"ocfnRegistrationSymbol\"  : \"registration-policy.symbol\""  >> $fileNamesJSONFile
+  echo ", \"ocfnRegistrationRefUTxO\" : \"registration-policy.refUTxO\"" >> $fileNamesJSONFile
+  echo ", \"ocfnDonationMinter\"      : \"donation-policy.plutus\""      >> $fileNamesJSONFile
+  echo ", \"ocfnDonationSymbol\"      : \"donation-policy.symbol\""      >> $fileNamesJSONFile
+  echo ", \"ocfnDonationRefUTxO\"     : \"donation-policy.refUTxO\""     >> $fileNamesJSONFile
+  echo ", \"ocfnQVFMainValidator\"    : \"$scriptLabel.plutus\""         >> $fileNamesJSONFile
+  echo ", \"ocfnQVFRefUTxO\"          : \"$scriptLabel.refUTxO\""        >> $fileNamesJSONFile
+  echo ", \"ocfnContractAddress\"     : \"$scriptLabel.addr\""           >> $fileNamesJSONFile
+  echo ", \"ocfnDeadlineSlot\"        : \"deadline.slot\""               >> $fileNamesJSONFile
+  echo ", \"ocfnDeadlineDatum\"       : \"deadline.govDatum\""           >> $fileNamesJSONFile
+  echo ", \"ocfnInitialGovDatum\"     : \"initial.govDatum\""            >> $fileNamesJSONFile
+  echo ", \"ocfnCurrentDatum\"        : \"current.datum\""               >> $fileNamesJSONFile
+  echo ", \"ocfnUpdatedDatum\"        : \"updated.datum\""               >> $fileNamesJSONFile
+  echo ", \"ocfnNewDatum\"            : \"new.datum\""                   >> $fileNamesJSONFile
+  echo ", \"ocfnQVFRedeemer\"         : \"qvf.redeemer\""                >> $fileNamesJSONFile
+  echo ", \"ocfnMinterRedeemer\"      : \"minter.redeemer\""             >> $fileNamesJSONFile
+  echo ", \"ocfnProjectTokenName\"    : \"project-token-name.hex\""      >> $fileNamesJSONFile
+  echo ", \"ocfnScriptUTxOs\"         : \"script.utxos\""                >> $fileNamesJSONFile
+  echo ", \"ocfnRegisteredProjects\"  : \"registered-projects.json\""    >> $fileNamesJSONFile
+  echo "}" >> $fileNamesJSONFile
+else
+  newContent=$(cat $fileNamesJSONFile | jq -c --arg preDir "$preDir" '.ocfnPreDir = $preDir')
+  echo "$newContent" > $fileNamesJSONFile
+fi
+# }}}
+touch $tempBashFile
+touch $tidyUpLogFile
+touch $refDepletionLogFile
+touch $projectTokenNameFile
+touch $registeredProjectsFile
+if [ ! "$(cat $registeredProjectsFile)" ]; then
+  echo "[]" > $registeredProjectsFile
+fi
+touch $latestInteractionSlotFile
+if [ ! "$(cat $latestInteractionSlotFile)" ]; then
+  echo "{\"$keyHolder\":0"        > $latestInteractionSlotFile
+  echo ",\"$referenceWallet\":0" >> $latestInteractionSlotFile
+  echo ",\"$scriptLabel\":0"     >> $latestInteractionSlotFile
+  echo ",\"deadline\":0"         >> $latestInteractionSlotFile
+  echo "}"                       >> $latestInteractionSlotFile
+fi
+touch $scriptUTxOsFile
+generate_protocol_params
+
+# REQUIRED FOR DEVELOPMENT:
+touch $devRedeemer
+echo "{\"constructor\":20,\"fields\":[]}" > $devRedeemer
+# =========================
+
+# Checks if the $keyHolder wallet exists (properly), and that it has a single
+# UTxO with enough Ada inside.
+#
+# If the wallet files exist partially, this function terminates the script
+# without any changes. If there are no wallet files, the $keyHolder wallet is
+# generated, but the script is terminated, prompting the user to send some Ada
+# to the wallet.
+#
+# If the wallet is present, it's made sure the total Lovelace count is more
+# than the minimum, and if they are spread out between multiple UTxOs, it'll
+# invoke the `tidy_up_wallet` function so that all the money is collected
+# inside a single UTxO.
+# {{{
+if [ -f $preDir/$keyHolder.vkey ] && [ -f $preDir/$keyHolder.skey ] && [ -f $preDir/$keyHolder.addr ] && [ -f $preDir/$keyHolder.pkh ]; then
+  keyHolder_utxos=$(get_wallet_lovelace_utxos $keyHolder)
+  keyHolder_utxoCount=$(echo "$keyHolder_utxos" | jq length)
+  keyHolder_totalLovelace=$(get_total_lovelaces_from_json "$keyHolder_utxos")
+  if [ $keyHolder_totalLovelace -ge $minStartingLovelaces ] || [ -f $scriptAddressFile ]; then
+    if [ $keyHolder_utxoCount -gt 1 ]; then
+      tidy_up_wallet $keyHolder "Multiple UTxOs found in the key holder's wallet. Tidying up...\n$keyHolder_utxos"
+      echo "Done. The key holder wallet is ready."
+    fi
+    export keyHoldersAddress=$(cat "$preDir/$keyHolder.addr")
+    export keyHoldersPubKeyHash=$(cat "$preDir/$keyHolder.pkh")
+    export keyHoldersSigningKeyFile="$preDir/$keyHolder.skey"
+  else
+    echo "The key holder wallet doesn't have enough Ada. Please make sure a"
+    echo -e "minimum of $WHITE$minStartingAda Ada$NO_COLOR is available:"
+    echo ""
+    echo -e "$WHITE$(cat $preDir/$keyHolder.addr)$NO_COLOR"
+    return 1
+  fi
+elif [ -f $preDir/$keyHolder.vkey ] || [ -f $preDir/$keyHolder.skey ] || [ -f $preDir/$keyHolder.addr ] || [ -f $preDir/$keyHolder.pkh ]; then
+  echo "Some key holder wallet files are missing."
+  return 1
+else
+  generate_wallet $keyHolder
+  echo "No key holder wallet was found. The wallet is generated for you."
+  echo -e "Please deposit a minimum of $WHITE$minStartingAda Ada$NO_COLOR before proceeding:"
+  echo ""
+  echo -e "$WHITE$(cat $preDir/$keyHolder.addr)$NO_COLOR"
+  return 1
+fi
+# }}}
+
+
+# A similar check for $collateralKeyHolder. This wallet is meant for providing
+# the collateral for user-facing endpoints to provide a more "approachable"
+# experience for non-technical users.
+# {{{
+if [ -f $preDir/$collateralKeyHolder.vkey ] && [ -f $preDir/$collateralKeyHolder.skey ] && [ -f $preDir/$collateralKeyHolder.addr ] && [ -f $preDir/$collateralKeyHolder.pkh ]; then
+  collateral_utxos=$(get_wallet_lovelace_utxos $collateralKeyHolder)
+  collateral_utxoCount=$(echo "$collateral_utxos" | jq length)
+  collateral_totalLovelace=$(get_total_lovelaces_from_json "$collateral_utxos")
+  if [ $collateral_totalLovelace -ge $minCollateralLovelaces ]; then
+    if [ $collateral_utxoCount -gt 1 ]; then
+      tidy_up_wallet $collateralKeyHolder "Multiple UTxOs found in the collateral key holder's wallet. Tidying up...\n$collateral_utxos"
+      echo "Done. The key holder wallet is ready."
+    fi
+    export collateralKeyHoldersAddress=$(cat "$preDir/$collateralKeyHolder.addr")
+    export collateralKeyHoldersPubKeyHash=$(cat "$preDir/$collateralKeyHolder.pkh")
+    export collateralKeyHoldersSigningKeyFile="$preDir/$collateralKeyHolder.skey"
+  else
+    echo "The collateral key holder wallet doesn't have enough Ada. Please make sure a"
+    echo -e "minimum of $WHITE$minCollateralAda Ada$NO_COLOR is available:"
+    echo ""
+    echo -e "$WHITE$(cat $preDir/$collateralKeyHolder.addr)$NO_COLOR"
+    return 1
+  fi
+elif [ -f $preDir/$collateralKeyHolder.vkey ] || [ -f $preDir/$collateralKeyHolder.skey ] || [ -f $preDir/$collateralKeyHolder.addr ] || [ -f $preDir/$collateralKeyHolder.pkh ]; then
+  echo "Some key holder wallet files are missing."
+  return 1
+else
+  generate_wallet $collateralKeyHolder
+  echo "No collateral key holder wallet was found. The wallet is generated for you."
+  echo -e "Please deposit a minimum of $WHITE$minCollateralAda Ada$NO_COLOR before proceeding:"
+  echo ""
+  echo -e "$WHITE$(cat $preDir/$collateralKeyHolder.addr)$NO_COLOR"
+  return 1
+fi
+# }}}
+
+
+# A similar check for the $referencWallet. There are 3 circumstances that lead
+# to an automated depletion of the $referenceWallet into $keyHolder:
+#   - There are some Lovelaces in the wallet, but the UTxO count is not exactly
+#     the same as the $scriptCount,
+#   - There are exactly $scriptCount UTxOs in the wallet, but there is no
+#     $scriptAddressFile,
+#   - There are exactly $scriptCount UTxOs in the wallet, but there are no
+#     Lovelaces stored at the found script address.
+# {{{
+if [ -f $preDir/$referenceWallet.vkey ] && [ -f $preDir/$referenceWallet.skey ] && [ -f $preDir/$referenceWallet.addr ] && [ -f $preDir/$referenceWallet.pkh ]; then
+  ref_wallet_utxos=$(get_wallet_lovelace_utxos $referenceWallet)
+  ref_wallet_utxoCount=$(echo "$ref_wallet_utxos" | jq length)
+  ref_wallet_totalLovelace=$(get_total_lovelaces_from_json "$ref_wallet_utxos")
+  if [ $ref_wallet_utxoCount -eq 3 ]; then
+    if [ -f $scriptAddressFile ]; then
+      qvf_utxos=$(get_all_script_utxos_datums_values $(cat $scriptAddressFile))
+      qvf_totalLovelace=$(get_total_lovelaces_from_json "$qvf_utxos")
+      if [ $qvf_totalLovelace -eq 0 ]; then
+        deplete_reference_wallet "The reference wallet is not empty, while the contract is. Depleting the reference wallet into key holder's...\n$ref_wallet_utxos"
+        tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to an un-initiated script address..."
+      fi
+    else
+      deplete_reference_wallet "The reference wallet is not empty, while there is no contract address file stored. Depleting the reference wallet...\n$ref_wallet_utxos"
+      tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to missing script address file..."
+    fi
+  elif [ $ref_wallet_totalLovelace -gt 0 ]; then
+    deplete_reference_wallet "The reference wallet has some Lovelaces, but the number of its UTxOs are not exactly 3 (the number of scripts). Depleting the reference wallet...\n$ref_wallet_utxos"
+    tidy_up_wallet $keyHolder "Tidying up the key holder's wallet after depletion of the reference wallet due to not having exactly 3 UTxOs, but having some Lovelaces..."
+  fi
+elif [ -f $preDir/$referenceWallet.vkey ] || [ -f $preDir/$referenceWallet.skey ] || [ -f $preDir/$referenceWallet.addr ] || [ -f $preDir/$referenceWallet.pkh ]; then
+  echo "Some reference wallet files are missing."
+  return 1
+else
+  generate_wallet $referenceWallet
+fi
+export referenceWalletAddress=$(cat "$preDir/$referenceWallet.addr")
+# }}}

--- a/scripts/update-deadline.sh
+++ b/scripts/update-deadline.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-. $REPO/scripts/initiation.sh
+. $REPO/scripts/env.sh
 
 export deadline=$1
 
+keyHoldersAddress=$(cat $preDir/$keyHolder.addr)
+keyHoldersPubKeyHash=$(cat $preDir/$keyHolder.pkh)
 qvfAddress=$(cat $scriptAddressFile)
 govAsset=$(cat $govSymFile)
 inUTxO=$(get_first_utxo_of $keyHolder)


### PR DESCRIPTION
Having both the setup (i.e. preparing the funding round's files) and the definition of utility functions in `env.sh` (which got sourced at the start of almost all other scripts) resulted in disruptive behavior due to its constant monitoring for the health of the key holders wallets and the reference wallet.

This PR separates the setup logic into another script which is only sourced before initiation of a new fund.